### PR TITLE
com.docker.slirp: fixed path for @connect socket

### DIFF
--- a/src/com.docker.slirp/src/connect.ml
+++ b/src/com.docker.slirp/src/connect.ml
@@ -1,4 +1,7 @@
-let vsock_path = ref "/var/tmp/com.docker.vsock/connect"
+
+let (/) = Filename.concat
+let home = try Sys.getenv "HOME" with Not_found -> "/Users/root"
+let vsock_path = ref (home / "Library/Containers/com.docker.docker/Data/@connect")
 
 module Port = struct
   type t = int32


### PR DESCRIPTION
The hyperkit virtio-vsock path has recently moved to the container folder.

Signed-off-by: Gaetan de Villele <gdevillele@gmail.com>
Imported-by: David Scott <dave.scott@docker.com>