### PR TITLE
com.docker.slirp.exe: on failure, close the socket

### DIFF
--- a/src/com.docker.slirp.exe/src/main.ml
+++ b/src/com.docker.slirp.exe/src/main.ml
@@ -76,6 +76,8 @@ let hvsock_connect_forever url sockaddr callback =
           Log.debug (fun f -> f "hvsock connect got %s: retrying in 1s" (Win_error.error_message e));
           Lwt_unix.sleep 1.
         | e ->
+          Lwt_hvsock.close socket
+          >>= fun () ->
           Log.err (fun f -> f "hvsock connect raised %s" (Printexc.to_string e));
           Lwt_unix.sleep 1.
       )


### PR DESCRIPTION
The recent change to avoid completely failing when the connect failed
neglected to close the socket. This results in a slow leak of sockets
(and 2 threads per socket) while the VM is offline.

Signed-off-by: David Scott <dave.scott@docker.com>