### PR TITLE
com.docker.slirp.exe: remove AF_HYPERV connection spam

### DIFF
--- a/src/com.docker.slirp.exe/src/main.ml
+++ b/src/com.docker.slirp.exe/src/main.ml
@@ -73,12 +73,10 @@ let hvsock_connect_forever url sockaddr callback =
         | Unix.Unix_error(e, _, _) ->
           Lwt_hvsock.close socket
           >>= fun () ->
-          Log.debug (fun f -> f "hvsock connect got %s: retrying in 1s" (Win_error.error_message e));
           Lwt_unix.sleep 1.
         | e ->
           Lwt_hvsock.close socket
           >>= fun () ->
-          Log.err (fun f -> f "hvsock connect raised %s" (Printexc.to_string e));
           Lwt_unix.sleep 1.
       )
     >>= fun () ->


### PR DESCRIPTION
When we're connecting to the VM, don't bother logging each individual
connection rejection -- it's not particularly useful information.

Signed-off-by: David Scott <dave.scott@docker.com>