### PR TITLE
Move mirage-net-unix version constraint to conflicts

### DIFF
--- a/packages/tcpip.999/opam
+++ b/packages/tcpip.999/opam
@@ -49,6 +49,9 @@ depends: [
 ]
 depopts: [
   "mirage-xen"
-  "mirage-net-unix" {>= "1.1.0"}
+  "mirage-net-unix"
+]
+conflicts: [
+  "mirage-net-unix" {< "1.1.0"}
 ]
 available: [ocaml-version >= "4.01.0"]


### PR DESCRIPTION
opam is complaining:

[WARNING] At ~/kits.opam/packages/tcpip/tcpip.999/opam:50:9:
          Version constraint (>= 1.1.0) no longer allowed in optional dependency (ignored).
          Use the 'conflicts' field instead.

As suggested turn the >= 1.1.0 version constraint into a conflict with < 1.1.0.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>