### PR TITLE
Attempt to make the build easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,11 @@ depends:
 	opam pin add -n hostnet src/hostnet -y
 	opam pin add -n osx-daemon src/osx-daemon -y
 	opam pin add -n osx-hyperkit src/osx-hyperkit -y
+ifeq ($(OS),Windows_NT)
+	opam pin add -n slirp src/com.docker.slirp.exe -y
+else
 	opam pin add -n slirp src/com.docker.slirp -y
+endif
 	opam depext -u slirp
 	opam install --deps-only slirp -y
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,30 @@
-.PHONY: com.docker.slirp.exe install uninstall
+.PHONY: com.docker.slirp.exe com.docker.slirp install uninstall
+
+TARGETS :=
+ifeq ($(OS),Windows_NT)
+	TARGETS += com.docker.slirp.exe
+else
+	TARGETS += com.docker.slirp
+endif
+
+all: $(TARGETS)
 
 EXEDIR=C:\projects\vpnkit
 
 com.docker.slirp:
-	cd src/com.docker.slirp && \
-	oasis setup && \
-	./configure && \
-	make && \
-	cp _build/src/main.native com.docker.slirp
+	$(MAKE) -C src/com.docker.slirp
+
+depends:
+	opam repo list | grep com-docker-slirp || opam repo add com-docker-slirp .
+	opam update com-docker-slirp
+	opam pin add -n proto-vmnet src/proto-vmnet -y
+	opam pin add -n ofs src/ofs -y
+	opam pin add -n hostnet src/hostnet -y
+	opam pin add -n osx-daemon src/osx-daemon -y
+	opam pin add -n osx-hyperkit src/osx-hyperkit -y
+	opam pin add -n slirp src/com.docker.slirp -y
+	opam depext -u slirp
+	opam install --deps-only slirp -y
 
 com.docker.slirp.exe:
 	cd src/com.docker.slirp.exe && \
@@ -21,4 +38,4 @@ install:
 	cp src/com.docker.slirp.exe/register.ps1 '$(EXEDIR)'
 
 uninstall:
-	echo uninstall
+	echo uninstall not implemented

--- a/README.md
+++ b/README.md
@@ -6,6 +6,24 @@ VPN-friendly networking devices for [HyperKit](https://github.com/docker/hyperki
 VPNkit is a set of tools and services for helping [HyperKit](https://github.com/docker/hyperkit)
 VMs interoperate with host VPN configurations.
 
+Building on Unix
+----------------
+
+First install `wget`, `opam` using your package manager of choice.
+Make sure you have OCaml 4.02.3, for example by running:
+```
+opam switch 4.02.3
+eval `opam config env`
+```
+Install the OCaml library dependencies with:
+```
+make depends
+```
+Build the application using:
+```
+make
+```
+
 Why is this needed?
 -------------------
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils -P curl -P make -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core"
 
 build_script:
-  - "%CYG_BASH% 'tar xf opam32.tar.xz'"
+  - "%CYG_BASH% 'tar xf ${APPVEYOR_BUILD_FOLDER}/opam32.tar.xz'"
   - "%CYG_BASH% 'opam32/install.sh'"
   - "%CYG_BASH% 'opam init -a default https://github.com/fdopen/opam-repository-mingw.git --comp=4.02.3 --switch=4.02.3+mingw64c'"
   - "%CYG_BASH% 'opam install depext-cygwinports depext ocamlfind'"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,7 @@ install:
   - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils -P curl -P make -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core"
 
 build_script:
-  - "%CYG_BASH% 'tar xf ${APPVEYOR_BUILD_FOLDER}/opam32.tar.xz'"
-  - "%CYG_BASH% 'opam32/install.sh'"
+  - "%CYG_BASH% 'cd ${APPVEYOR_BUILD_FOLDER} && tar xf opam32.tar.xz && opam32/install.sh'"
   - "%CYG_BASH% 'opam init -a default https://github.com/fdopen/opam-repository-mingw.git --comp=4.02.3 --switch=4.02.3+mingw64c'"
   - "%CYG_BASH% 'opam install depext-cygwinports depext ocamlfind'"
   - "%CYG_BASH% 'make depends'"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,16 @@ environment:
   TESTS: "false"
 
 install:
-  - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
+  - appveyor DownloadFile https://dl.dropboxusercontent.com/s/eo4igttab8ipyle/opam32.tar.xz
   - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils -P curl -P make -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core"
 
 build_script:
-  - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"
+  - "%CYG_BASH% 'tar xf opam32.tar.xz'"
+  - "%CYG_BASH% 'opam32/install.sh'"
+  - "%CYG_BASH% 'opam init -a default https://github.com/fdopen/opam-repository-mingw.git --comp=4.02.3 --switch=4.02.3+mingw64c'"
+  - "%CYG_BASH% 'opam install depext-cygwinports depext ocamlfind'"
+  - "%CYG_BASH% 'make depends'"
+  - "%CYG_BASH% 'make'"
 
 artifacts:
   - path: "com.docker.slirp.exe"

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,9 @@ machine:
     OPAMVERBOSE: "1"
     OPAMJOBS: "2"
     MACOSX_DEPLOYMENT_TARGET: "10.10"
+general:
+  artifacts:
+  - src/com.docker.slirp/bundle.tgz
 dependencies:
   override:
   - brew install wget opam dylibbundler

--- a/circle.yml
+++ b/circle.yml
@@ -11,16 +11,8 @@ dependencies:
   - brew install wget opam dylibbundler
   - rm -rf ~/.opam && opam init -a git://github.com/ocaml/opam-repository
   - opam switch 4.02.3
-  - opam repo add dev .
-  - opam pin add -n proto-vmnet src/proto-vmnet
-  - opam pin add -n ofs src/ofs
-  - opam pin add -n hostnet src/hostnet
-  - opam pin add -n osx-daemon src/osx-daemon
-  - opam pin add -n osx-hyperkit src/osx-hyperkit
-  - opam pin add -n slirp src/com.docker.slirp
-  - opam depext -u slirp
-  - opam install --deps-only slirp
-  - cd src/com.docker.slirp && make bundle
+  - make depends
+  - make
 test:
   override:
   - echo Dummy test

--- a/src/com.docker.slirp.exe/opam
+++ b/src/com.docker.slirp.exe/opam
@@ -4,15 +4,6 @@ version: "0.0.0"
 maintainer: "David Scott <dave.scott@docker.com>"
 authors: [ "David Scott <dave.scott@docker.com>" ]
 
-build: [
-  [make "com.docker.slirp.exe"]
-]
-build-test: [
-  [make "test"]
-]
-install: [make "install"]
-remove: [make "uninstall"]
-
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}

--- a/src/com.docker.slirp/Makefile
+++ b/src/com.docker.slirp/Makefile
@@ -1,3 +1,13 @@
+TARGETS := build
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	TARGETS += bundle
+endif
+
+all: $(TARGETS)
+
+
 SETUP = ocaml setup.ml
 
 setup.ml:
@@ -11,9 +21,6 @@ doc: setup.data build
 
 test: setup.data build
 	$(SETUP) -test $(TESTFLAGS)
-
-all:
-	$(SETUP) -all $(ALLFLAGS)
 
 install: setup.data
 	$(SETUP) -install $(INSTALLFLAGS)

--- a/src/com.docker.slirp/Makefile
+++ b/src/com.docker.slirp/Makefile
@@ -2,7 +2,7 @@ TARGETS := build
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-	TARGETS += bundle
+	TARGETS += bundle.tgz
 endif
 
 all: $(TARGETS)
@@ -43,6 +43,10 @@ clean:
 	rm -rf _build setup.data
 	rm -f com.docker.slirp
 
+bundle.tgz: bundle
+	tar -cvzf bundle.tgz _build/root
+
+.PHONY: bundle
 bundle: build
 	mkdir -p _build/root/Contents/MacOS
 	mv main.native com.docker.slirp


### PR DESCRIPTION
The idea is to have 3 phases:

1. `circle.yml` and `appveyor.yml` install basic prerequisites like `opam`
2. `make depends` installs the library dependencies and sets up pins
3. `make` builds the component
