### PR TITLE
Have Dns_forward operate on ipv4 and udpv4 modules, not an entire stack

### DIFF
--- a/src/hostnet/lib/dns_forward.ml
+++ b/src/hostnet/lib/dns_forward.ml
@@ -23,10 +23,10 @@ let string_of_dns buf =
   | Some request ->
     Dns.Packet.to_string request
 
-module Make(Tcpip_stack: Sig.TCPIP)(Resolv_conf: Sig.RESOLV_CONF) = struct
+module Make(Ip: V1_LWT.IPV4) (Udp:V1_LWT.UDPV4) (Resolv_conf: Sig.RESOLV_CONF) = struct
 
-let input s ~src ~dst ~src_port buf =
-  if List.mem dst (Tcpip_stack.IPV4.get_ip (Tcpip_stack.ipv4 s)) then begin
+let input ~ip ~udp ~src ~dst ~src_port buf =
+  if List.mem dst (Ip.get_ip ip) then begin
 
   let src_str = Ipaddr.V4.to_string src in
   let dst_str = Ipaddr.V4.to_string dst in
@@ -85,7 +85,7 @@ let input s ~src ~dst ~src_port buf =
       Lwt.return_unit
     | `Result buffer ->
       Log.debug (fun f -> f "DNS %s:%d <- %s %s" src_str src_port dst_str (string_of_dns buffer));
-      Tcpip_stack.UDPV4.write ~source_port:53 ~dest_ip:src ~dest_port:src_port (Tcpip_stack.udpv4 s) buffer
+      Udp.write ~source_port:53 ~dest_ip:src ~dest_port:src_port udp buffer
     end
   | _ ->
     Log.err (fun f -> f "No upstream DNS server configured: dropping request");

--- a/src/hostnet/lib/dns_forward.mli
+++ b/src/hostnet/lib/dns_forward.mli
@@ -1,3 +1,6 @@
-module Make(Tcpip_stack: Sig.TCPIP)(Resolv_conv: Sig.RESOLV_CONF): sig
-val input: Tcpip_stack.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
+module Make
+    (Ip: V1_LWT.IPV4 with type prefix = Ipaddr.V4.t)
+    (Udp: V1_LWT.UDPV4)
+    (Resolv_conv: Sig.RESOLV_CONF) : sig
+  val input: ip:Ip.t -> udp:Udp.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
 end

--- a/src/hostnet/lib/sig.ml
+++ b/src/hostnet/lib/sig.ml
@@ -32,6 +32,8 @@ module type TCPIP = sig
   (** A TCP/IP stack *)
 
   include V1_LWT.STACKV4
+    with type IPV4.prefix = Ipaddr.V4.t
+     and type IPV4.uipaddr = Ipaddr.t
 
   module TCPV4_half_close : Mirage_flow_s.SHUTDOWNABLE
     with type flow = TCPV4.flow


### PR DESCRIPTION
Users will no longer have to construct additional modules and records which won't be used by Dns_forward.