### PR TITLE
Fallback to secondary DNS servers upon retries

### DIFF
--- a/src/hostnet/lib/dns_forward.mli
+++ b/src/hostnet/lib/dns_forward.mli
@@ -2,5 +2,6 @@ module Make
     (Ip: V1_LWT.IPV4 with type prefix = Ipaddr.V4.t)
     (Udp: V1_LWT.UDPV4)
     (Resolv_conv: Sig.RESOLV_CONF) : sig
+  val start_reaper: unit -> unit Lwt.t
   val input: ip:Ip.t -> udp:Udp.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
 end

--- a/src/hostnet/lib/slirp.ml
+++ b/src/hostnet/lib/slirp.ml
@@ -285,6 +285,7 @@ let connect x peer_ip local_ip =
       local_ip;
       pcap_settings;
     } in
+    Lwt.async (fun () -> Dns_forward.start_reaper ());
     Lwt.return t
 
   let connect t client =


### PR DESCRIPTION
If the first upstream DNS server fails to respond then the guest will retry, today we would forward the retry to the same server, whereas on a native system it would try the next server in `resolv.conf`. This makes vpnkit more susceptible to errors due to a flakey upsteam server.

To resolve this keep track of in progress DNS requests and if we observe a reuse of a transaction id round-robin through the upstream servers instead of reusing the first.