### PR TITLE
com.docker.slirp: Bump nofile rlimit to 10240

### DIFF
--- a/src/com.docker.slirp/_oasis
+++ b/src/com.docker.slirp/_oasis
@@ -15,4 +15,4 @@ Executable Main
   Path: src
   MainIs: main.ml
   BuildDepends: hostnet, osx-daemon, osx-hyperkit, ofs, protocol-9p,
-    protocol-9p.unix, proto-vmnet, vmnet-client, cmdliner
+    protocol-9p.unix, proto-vmnet, vmnet-client, cmdliner, unix-sys-resource.unix

--- a/src/com.docker.slirp/opam
+++ b/src/com.docker.slirp/opam
@@ -18,6 +18,7 @@ depends: [
   "logs"
   "fmt"
   "proto-vmnet"
+  "unix-sys-resource"
   "fd-send-recv" # to enable vmnet-client
   "unix-errno" # to enable vmnet-client
   "ctypes" # to enable vmnet-client


### PR DESCRIPTION
This is the maximum on OSX, while the default is 256 which can be quite quickly
exhausted by parallel network traffic.

Also plumb through as a command line option.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>