### PR TITLE
Send TCP addressed to us, to us rather than to someone else

### DIFF
--- a/src/hostnet/lib/slirp.ml
+++ b/src/hostnet/lib/slirp.ml
@@ -149,7 +149,8 @@ let connect x peer_ip local_ip =
                     (Ipaddr.V4.to_string src_ip) src_port
                     (Ipaddr.V4.to_string dst_ip) dst_port in
                 Log.debug (fun f -> f "%s connecting" description);
-                ( if Ipaddr.V4.compare src_ip local_ip == 0 && src_port = 53 then begin
+                let for_us = Ipaddr.V4.compare src_ip local_ip == 0 in
+                ( if for_us && src_port = 53 then begin
                     Dns_resolver_unix.create () (* re-read /etc/resolv.conf *)
                     >>= function
                     | { Dns_resolver_unix.servers = (Ipaddr.V4 ip, port) :: _; _ } -> Lwt.return (ip, port)

--- a/src/hostnet/lib/slirp.ml
+++ b/src/hostnet/lib/slirp.ml
@@ -159,6 +159,9 @@ let connect x peer_ip local_ip =
                       Lwt.return (Ipaddr.V4.of_string_exn "127.0.0.1", 53)
                   end else Lwt.return (src_ip, src_port)
                 ) >>= fun (src_ip, src_port) ->
+                (* If the traffic is for us, use a local IP address that is really
+                   ours, rather than send traffic off to someone else (!) *)
+                let src_ip = if for_us then Ipaddr.V4.localhost else src_ip in
                 Socket.Stream.connect_v4 src_ip src_port
                 >>= function
                 | `Error (`Msg m) ->


### PR DESCRIPTION
Currently if the peer sends TCP traffic to us on port 53 then we process it. If the peer sends TCP traffic to us on other ports then we try to make a connection on on the *outside* network to the IP from the *inside* network. This seems wrong because

-  the internal IP is arbitrary and only valid on the inside network, so we should only use it on the inside network
- the peer has deliberately directly addressed us, so we should treat it as a connection request to us and respond as such.

This PR redirects connections sent to the gateway IP (i.e. "bound" to the virtual interface inside vpnkit) to 127.0.0.1 on the host running vpnkit. In the context of Docker for Mac this would allow services to be run on the host and then accessed from a suitably privileged container (`--privileged --net=host`).