### PR TITLE
When binds include localhost, try to bind ::1 as well

### DIFF
--- a/src/com.docker.slirp/src/bind.ml
+++ b/src/com.docker.slirp/src/bind.ml
@@ -23,7 +23,7 @@ let request_privileged_port local_ip local_port sock_stream =
         begin match r with
         | `Ok fd ->
           Log.debug (fun f -> f "Received fd successfully");
-          Lwt.return (Result.Ok fd)
+          Lwt.return (Result.Ok [ fd ])
         | `Error (`Msg x) ->
           Log.err (fun f -> f "Error binding to %s:%d: %s" (Ipaddr.V4.to_string local_ip) local_port x);
           Lwt.return (Result.Error (`Msg x))

--- a/src/hostnet/lib/forward.ml
+++ b/src/hostnet/lib/forward.ml
@@ -143,11 +143,7 @@ let start_tcp_proxy vsock_path_var _local_ip _local_port fd t =
     ) (fun e ->
         Lwt_unix.close fd
         >>= fun () ->
-        (* Pretty-print the most common exception *)
-        let message = match e with
-        | Unix.Unix_error(Unix.EADDRINUSE, _, _) -> "address already in use"
-        | e -> Printexc.to_string e in
-        Lwt.return (Result.Error (`Msg (Printf.sprintf "failed to bind port: %s" message)))
+        Lwt.return (Result.Error (`Msg (Printf.sprintf "failed to listen: %s" (Printexc.to_string e))))
       )
   >>= function
   | Result.Error e -> Lwt.return (Result.Error e)

--- a/src/hostnet/lib/port.ml
+++ b/src/hostnet/lib/port.ml
@@ -11,7 +11,11 @@ let bind local_ip local_port sock_stream =
       (fun e ->
        Lwt_unix.close fd
        >>= fun () ->
-       Lwt.return (Result.Error (`Msg (Printf.sprintf "Failed to bind %s %s:%d %s"
-         (if sock_stream then "SOCK_STREAM" else "SOCK_DGRAM")
-         (Ipaddr.V4.to_string local_ip) local_port (Printexc.to_string e))))
+        (* Pretty-print the most common exception *)
+        let message = match e with
+        | Unix.Unix_error(Unix.EADDRINUSE, _, _) -> "address already in use"
+        | e -> Printexc.to_string e in
+          Lwt.return (Result.Error (`Msg (Printf.sprintf "Failed to bind %s %s:%d %s"
+         (if sock_stream then "tcp" else "udp")
+         (Ipaddr.V4.to_string local_ip) local_port message)))
       )

--- a/src/hostnet/lib/port.ml
+++ b/src/hostnet/lib/port.ml
@@ -7,7 +7,7 @@ let bind local_ip local_port sock_stream =
       (fun () ->
        Lwt_unix.setsockopt fd Lwt_unix.SO_REUSEADDR true;
        Lwt_unix.bind fd addr;
-       Lwt.return (Result.Ok fd))
+       Lwt.return (Result.Ok [ fd ]))
       (fun e ->
        Lwt_unix.close fd
        >>= fun () ->

--- a/src/hostnet/lib/port.ml
+++ b/src/hostnet/lib/port.ml
@@ -1,21 +1,63 @@
 open Lwt.Infix
 
+let src =
+  let src = Logs.Src.create "port forward" ~doc:"forward local ports to the VM" in
+  Logs.Src.set_level src (Some Logs.Debug);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let common pf ty ip port =
+  let addr = Lwt_unix.ADDR_INET(Unix.inet_addr_of_string @@ Ipaddr.to_string ip, port) in
+  let fd = Lwt_unix.socket pf ty 0 in
+  Lwt.catch
+    (fun () ->
+      Lwt_unix.setsockopt fd Lwt_unix.SO_REUSEADDR true;
+      Lwt_unix.bind fd addr;
+      Lwt.return fd
+    ) (fun e ->
+      Lwt_unix.close fd
+      >>= fun () ->
+      Lwt.fail e
+    )
+
 let bind local_ip local_port sock_stream =
-    let addr = Lwt_unix.ADDR_INET(Unix.inet_addr_of_string (Ipaddr.V4.to_string local_ip), local_port) in
-    let fd = Lwt_unix.socket Lwt_unix.PF_INET (if sock_stream then Lwt_unix.SOCK_STREAM else Lwt_unix.SOCK_DGRAM) 0 in
-    Lwt.catch
-      (fun () ->
-       Lwt_unix.setsockopt fd Lwt_unix.SO_REUSEADDR true;
-       Lwt_unix.bind fd addr;
-       Lwt.return (Result.Ok [ fd ]))
-      (fun e ->
-       Lwt_unix.close fd
-       >>= fun () ->
-        (* Pretty-print the most common exception *)
-        let message = match e with
-        | Unix.Unix_error(Unix.EADDRINUSE, _, _) -> "address already in use"
-        | e -> Printexc.to_string e in
-          Lwt.return (Result.Error (`Msg (Printf.sprintf "Failed to bind %s %s:%d %s"
+  let ty = if sock_stream then Lwt_unix.SOCK_STREAM else Lwt_unix.SOCK_DGRAM in
+  Lwt.catch
+    (fun () ->
+      common Lwt_unix.PF_INET ty Ipaddr.(V4 local_ip) local_port
+      >>= fun fd ->
+      let local_port = match local_port, Lwt_unix.getsockname fd with
+        | 0, Unix.ADDR_INET(_, local_port) -> local_port
+        | 0, _ -> assert false (* common only uses ADDR_INET *)
+        | _ -> local_port in
+      (* On some systems localhost will resolve to ::1 first and this can
+         cause performance problems (particularly on Windows). Perform a
+         best-effort bind to the ::1 address. *)
+      Lwt.catch
+        (fun () ->
+          if Ipaddr.V4.compare local_ip Ipaddr.V4.localhost = 0
+          || Ipaddr.V4.compare local_ip Ipaddr.V4.any = 0
+          then begin
+            Log.info (fun f -> f "attempting a best-effort bind of ::1:%d" local_port);
+            common Lwt_unix.PF_INET6 ty Ipaddr.(V6 V6.localhost) local_port
+            >>= fun fd ->
+            Lwt.return [ fd ]
+          end else begin
+            Lwt.return []
+          end
+        ) (fun e ->
+          Log.info (fun f -> f "ignoring failed bind to ::1:%d (%s)" local_port (Printexc.to_string e));
+          Lwt.return []
+        )
+      >>= fun extra ->
+      Lwt.return (Result.Ok (fd :: extra))
+    ) (fun e ->
+      (* Pretty-print the most common exception *)
+      let message = match e with
+      | Unix.Unix_error(Unix.EADDRINUSE, _, _) -> "address already in use"
+      | e -> Printexc.to_string e in
+        Lwt.return (Result.Error (`Msg (Printf.sprintf "Failed to bind %s %s:%d %s"
          (if sock_stream then "tcp" else "udp")
          (Ipaddr.V4.to_string local_ip) local_port message)))
       )

--- a/src/hostnet/lib/port.mli
+++ b/src/hostnet/lib/port.mli
@@ -1,4 +1,4 @@
 val bind: Ipaddr.V4.t -> int -> bool
-  -> (Lwt_unix.file_descr, [> `Msg of string ]) Result.result Lwt.t
+  -> (Lwt_unix.file_descr list, [> `Msg of string ]) Result.result Lwt.t
 (** [bind local_ip local_port stream] binds a socket on [local_ip:local_port].
     If [stream] then the socket is SOCK_STREAM, otherwise SOCK_DGRAM. *)

--- a/src/hostnet/lib/sig.ml
+++ b/src/hostnet/lib/sig.ml
@@ -55,7 +55,9 @@ end
 module type Binder = sig
   (** Bind local ports *)
 
-  val bind: Ipaddr.V4.t -> int -> bool -> (Lwt_unix.file_descr, [> `Msg of string]) Result.result Lwt.t
+  val bind: Ipaddr.V4.t -> int -> bool -> (Lwt_unix.file_descr list, [> `Msg of string]) Result.result Lwt.t
   (** [bind local_ip local_port stream] binds [local_ip:local_port] with
-      either a SOCK_STREAM if [stream] is true, or SOCK_DGRAM otherwise *)
+      either a SOCK_STREAM if [stream] is true, or SOCK_DGRAM otherwise.
+      Note the result can be a list of fds in some cases (typically where
+      one is TCP4 and another is TCP6. *)
 end


### PR DESCRIPTION
On some platforms (at least Windows) accessing ports via `localhost` is very slow because the address `::1` will be tried first and will be allowed to timeout. This patch generalises the port bindings a little, allowing a single user-requested binding to be mapped to a list of listening sockets. When the user requests an address `0.0.0.0` or `127.0.0.1` we perform a best-effort bind to `::1` also to speed up accesses on these IPv6 platforms.