### PR TITLE
Monitor the database for upstream DNS server overrides

### DIFF
--- a/src/com.docker.slirp.exe/src/main.ml
+++ b/src/com.docker.slirp.exe/src/main.ml
@@ -113,7 +113,7 @@ let main_t socket_url port_control_url max_connections db_path dns pcap debug =
   );
   Printexc.record_backtrace true;
 
-  Resolv_conf.set_dns dns;
+  Resolv_conf.set_default_dns [ (Ipaddr.V4 (Ipaddr.V4.of_string_exn dns)), 53 ];
 
   Lwt.async_exception_hook := (fun exn ->
     Log.err (fun f -> f "Lwt.async failure %s: %s"

--- a/src/com.docker.slirp.exe/src/resolv_conf.ml
+++ b/src/com.docker.slirp.exe/src/resolv_conf.ml
@@ -5,11 +5,23 @@ let src =
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let upstream_dns = ref (Ipaddr.V4.of_string_exn "127.0.0.1")
+let default_dns = ref [ Ipaddr.V4 (Ipaddr.V4.of_string_exn "127.0.0.1"), 53 ]
 
-let set_dns dns =
-  Log.info (fun f -> f "using DNS forwarder on %s:53" dns);
-  upstream_dns := (Ipaddr.V4.of_string_exn dns)
+let set_default_dns dns = default_dns := dns
+
+let current_dns = ref !default_dns
+
+let set = function
+  | _ :: _ as dns ->
+    Log.info (fun f -> f "using DNS forwarders on %s"
+      (String.concat "; " (List.map (fun (ip, port) -> Ipaddr.to_string ip ^ "#" ^ (string_of_int port)) dns))
+    );
+    current_dns := dns
+  | [] ->
+    Log.info (fun f -> f "using default DNS on %s"
+      (String.concat "; " (List.map (fun (ip, port) -> Ipaddr.to_string ip ^ "#" ^ (string_of_int port)) !default_dns))
+    );
+    current_dns := !default_dns
 
 let get () =
-  Lwt.return [ Ipaddr.V4 !upstream_dns, 53 ]
+  Lwt.return !current_dns

--- a/src/com.docker.slirp.exe/src/resolv_conf.mli
+++ b/src/com.docker.slirp.exe/src/resolv_conf.mli
@@ -1,3 +1,3 @@
 include Hostnet.Sig.RESOLV_CONF
 
-val set_dns: string -> unit
+val set_default_dns: (Ipaddr.t * int) list -> unit

--- a/src/com.docker.slirp/src/resolv_conf.ml
+++ b/src/com.docker.slirp/src/resolv_conf.ml
@@ -13,24 +13,31 @@ let resolv_conf = "/etc/resolv.conf"
 
 module Make(Files: Sig.FILES) = struct
 
+  let upstream_dns = ref []
+
+  let set dns = upstream_dns := dns
+
   let get () =
-    Files.read_file resolv_conf
-    >>= function
-    | `Error (`Msg m) ->
-      Log.err (fun f -> f "Error reading %s: %s" resolv_conf m);
-      Lwt.return []
-    | `Ok txt ->
-      let lines = Astring.String.cuts ~sep:"\n" txt in
-      let config = List.rev @@ List.fold_left (fun acc x ->
-          match map_line x with
-          | None -> acc
-          | Some x ->
-            begin
-              try
-                KeywordValue.of_string x :: acc
-              with
-              | _ -> acc
-            end
-        ) [] lines in
-      Lwt.return (all_servers config)
+    match !upstream_dns with
+    | _ :: _ as dns -> Lwt.return dns
+    | [] ->
+      Files.read_file resolv_conf
+      >>= function
+      | `Error (`Msg m) ->
+        Log.err (fun f -> f "Error reading %s: %s" resolv_conf m);
+        Lwt.return []
+      | `Ok txt ->
+        let lines = Astring.String.cuts ~sep:"\n" txt in
+        let config = List.rev @@ List.fold_left (fun acc x ->
+            match map_line x with
+            | None -> acc
+            | Some x ->
+              begin
+                try
+                  KeywordValue.of_string x :: acc
+                with
+                | _ -> acc
+              end
+          ) [] lines in
+        Lwt.return (all_servers config)
 end

--- a/src/hostnet/_oasis
+++ b/src/hostnet/_oasis
@@ -15,7 +15,7 @@ Library hostnet
   Pack: true
   Findlibname: hostnet
   Modules: Arp, Dns_forward, Filter, Slirp, Tcpip_stack,
-    Forward, Host_lwt_unix, Host_uwt, Sig
+    Forward, Host_lwt_unix, Host_uwt, Resolver, Sig
   BuildDepends: cstruct, lwt.unix, logs, mirage-types.lwt, ipaddr, mirage-flow,
     mirage-console.unix, tcpip.ethif,
     tcpip.arpv4, tcpip.ipv4, tcpip.udp, tcpip.tcp, tcpip.stack-direct,

--- a/src/hostnet/lib/resolver.ml
+++ b/src/hostnet/lib/resolver.ml
@@ -1,0 +1,25 @@
+
+let parse_resolvers txt =
+  let open Astring in
+  try
+    let lines = String.cuts ~sep:"\n" txt in
+    Some (List.rev (List.fold_left
+      (fun acc line ->
+        let line = String.trim line in
+        if line = "" then acc
+        else if String.cut ~sep:"::" line <> None then begin
+          (* IPv6 *)
+          let host = Ipaddr.V6.of_string_exn line in
+          (Ipaddr.V6 host, 53) :: acc
+        end else match String.cut ~sep:"#" line with
+          | Some (host, port) ->
+            (* IPv4 with non-standard port *)
+            let host = Ipaddr.V4.of_string_exn host in
+            let port = int_of_string port in
+            (Ipaddr.V4 host, port) :: acc
+          | None ->
+            (* IPv4 with standard port *)
+            let host = Ipaddr.V4.of_string_exn line in
+            (Ipaddr.V4 host, 53) :: acc
+      ) [] lines))
+  with _ -> None

--- a/src/hostnet/lib/resolver.mli
+++ b/src/hostnet/lib/resolver.mli
@@ -1,0 +1,3 @@
+
+val parse_resolvers: string -> (Ipaddr.t * int) list option
+(** [parse_resolvers data] parses DNS resolvers stored in a string *)

--- a/src/hostnet/lib/sig.ml
+++ b/src/hostnet/lib/sig.ml
@@ -172,6 +172,8 @@ module type RESOLV_CONF = sig
   (** The system DNS configuration *)
 
   val get : unit -> (Ipaddr.t * int) list Lwt.t
+
+  val set : (Ipaddr.t * int) list -> unit
 end
 
 

--- a/src/hostnet/lib_test/main.ml
+++ b/src/hostnet/lib_test/main.ml
@@ -10,6 +10,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module Resolv_conf = struct
   let get () = Lwt.return [ Ipaddr.V4 (Ipaddr.V4.of_string_exn "8.8.8.8"), 53 ]
+  let set _ = ()
 end
 
 module Make(Host: Sig.HOST) = struct
@@ -213,7 +214,8 @@ module Slirp_uwt = Make(Host_uwt)
 
 let tests =
   (List.map (fun (name, test) -> name ^ " with Lwt_unix", test) Slirp_lwt_unix.suite) @
-  (List.map (fun (name, test) -> name ^ " with Uwt", test) Slirp_uwt.suite)
+  (List.map (fun (name, test) -> name ^ " with Uwt", test) Slirp_uwt.suite) @
+  Resolver_test.suite
 
 (* Run it *)
 let () =

--- a/src/hostnet/lib_test/resolver_test.ml
+++ b/src/hostnet/lib_test/resolver_test.ml
@@ -1,0 +1,29 @@
+
+
+let examples = [
+  "10.0.0.2\n1.2.3.4#54", [
+    Ipaddr.V4 (Ipaddr.V4.of_string_exn "10.0.0.2"), 53;
+    Ipaddr.V4 (Ipaddr.V4.of_string_exn "1.2.3.4"), 54;
+  ];
+  "10.0.0.2\n", [
+    Ipaddr.V4 (Ipaddr.V4.of_string_exn "10.0.0.2"), 53;
+  ];
+]
+
+let test_one txt expected () =
+  match Hostnet.Resolver.parse_resolvers txt with
+  | None ->
+    failwith "None"
+  | Some x ->
+    List.iter (fun ((a, a_port), (b, b_port)) ->
+      if Ipaddr.compare a b <> 0 then failwith "IP doesn't match";
+      if a_port <> b_port then failwith "port doesn't match"
+    ) (List.combine expected x)
+
+let tests = List.map (fun (txt, expected) ->
+  "DNS " ^ (String.escaped txt), `Quick, test_one txt expected
+) examples
+
+let suite = [
+  "Resolver parsing", tests;
+]


### PR DESCRIPTION
If someone writes the key

  com.docker.driver.amd64-linux/slirp/dns

with \n-separated lines of the form

  a.b.c.d
  a.b.c.d#e

then these will override the default host DNS servers. If the key is deleted
then the original behaviour is restored (i.e. on Mac read /etc/resolv.conv
and on Windows use the command-line or 127.0.0.1:53)

This means that, for example, a UI would be able to choose the upstream
DNS server without the VM noticing the change. It also lets us separate the
detection of upstream DNS logic (which might use lots of platform-specific
magic) from the DNS forwarder itself-- we can keep the bulk of this code
pure and isolate the platform specific part using the database for communication.