### PR TITLE
hostnet: fix TCP DNS (required when UDP responses are truncated)

### DIFF
--- a/src/hostnet/lib/slirp.ml
+++ b/src/hostnet/lib/slirp.ml
@@ -153,8 +153,8 @@ let connect x peer_ip local_ip =
             Tcpip_stack.listen_tcpv4_flow s ~on_flow_arrival:(
               fun ~src:(src_ip, src_port) ~dst:(dst_ip, dst_port) ->
 
-                let for_us = Ipaddr.V4.compare src_ip local_ip == 0 in
-                ( if for_us && src_port = 53 then begin
+                let for_us src_ip = Ipaddr.V4.compare src_ip local_ip == 0 in
+                ( if for_us src_ip && src_port = 53 then begin
                     Resolv_conf.get () (* re-read /etc/resolv.conf *)
                     >>= function
                     | (Ipaddr.V4 ip, port) :: _  -> Lwt.return (ip, port)
@@ -165,7 +165,7 @@ let connect x peer_ip local_ip =
                 ) >>= fun (src_ip, src_port) ->
                 (* If the traffic is for us, use a local IP address that is really
                    ours, rather than send traffic off to someone else (!) *)
-                let src_ip = if for_us then Ipaddr.V4.localhost else src_ip in
+                let src_ip = if for_us src_ip then Ipaddr.V4.localhost else src_ip in
                 Socket.Stream.Tcp.connect (src_ip, src_port)
                 >>= function
                 | `Error (`Msg _) ->


### PR DESCRIPTION
TCP connections sent to our IP are normally forwarded to the host,
except for port 53 (DNS) which is forwarded to an upstream DNS
server.

Previously we checked whether a connection was "for us" by comparing
the IP destination to our IP. If a connection was for port 53 we would
then rewrite the IP destination but we failed to reconsider whether
this new IP was ours or not. This meant that we always forwarded TCP
on 53 to localhost by mistake.

This patch makes the "is connection for us" decision into a
function `for_us` and re-evaluates it when the destination IP may have
changed.

This fixes a bug introduced in a56356fd427870f7f3679b8dc9db6f403ea394db

Signed-off-by: David Scott <dave.scott@docker.com>