### PR TITLE
On startup log subcomponent versions

### DIFF
--- a/src/com.docker.slirp.exe/Makefile
+++ b/src/com.docker.slirp.exe/Makefile
@@ -3,8 +3,10 @@ build: src/depends.ml
 
 src/depends.ml: src/depends.ml.in
 	opam config subst src/depends.ml
-	sed -e 's/%%HOSTNET_PINNED%%/$(shell opam info hostnet -f pinned)/g' -i tmp src/depends.ml
-	sed -e 's/%%HVSOCK_PINNED%%/$(shell opam info hvsock -f pinned)/g' -i tmp src/depends.ml
+	cp src/depends.ml src/depends.tmp
+	sed -e 's/%%HOSTNET_PINNED%%/$(shell opam info hostnet -f pinned)/g' src/depends.tmp > src/depends.ml
+	cp src/depends.ml src/depends.tmp
+	sed -e 's/%%HVSOCK_PINNED%%/$(shell opam info hvsock -f pinned)/g' src/depends.tmp > src/depends.ml
 
 clean:
 	rm -rf _build/

--- a/src/com.docker.slirp.exe/Makefile
+++ b/src/com.docker.slirp.exe/Makefile
@@ -1,5 +1,11 @@
-build:
+build: src/depends.ml
 	ocaml pkg/pkg.ml build --vcs true --pinned true
+
+src/depends.ml: src/depends.ml.in
+	opam config subst src/depends.ml
+	sed -e 's/%%HOSTNET_PINNED%%/$(shell opam info hostnet -f pinned)/g' -i tmp src/depends.ml
+	sed -e 's/%%HVSOCK_PINNED%%/$(shell opam info hvsock -f pinned)/g' -i tmp src/depends.ml
 
 clean:
 	rm -rf _build/
+	rm -f src/depends.ml

--- a/src/com.docker.slirp.exe/src/depends.ml.in
+++ b/src/com.docker.slirp.exe/src/depends.ml.in
@@ -1,0 +1,5 @@
+let hostnet_version = "%{hostnet:version}%"
+let hostnet_pinned = "%%HOSTNET_PINNED%%"
+let uwt_version = "%{uwt:version}%"
+let hvsock_version = "%{hvsock:version}%"
+let hvsock_pinned = "%%HVSOCK_PINNED%%"

--- a/src/com.docker.slirp.exe/src/main.ml
+++ b/src/com.docker.slirp.exe/src/main.ml
@@ -99,7 +99,9 @@ let main_t socket_url port_control_url db_path dns pcap debug =
     let h = Eventlog.register "Docker.exe" in
     Logs.set_reporter (Log_eventlog.reporter ~eventlog:h ());
   end;
-  Log.info (fun f -> f "vpnkit version %%VERSION%%");
+  Log.info (fun f -> f "vpnkit version %%VERSION%% with hostnet version %s %s uwt version %s hvsock version %s %s"
+    Depends.hostnet_version Depends.hostnet_pinned Depends.uwt_version Depends.hvsock_version Depends.hvsock_pinned
+  );
   Printexc.record_backtrace true;
 
   Resolv_conf.set_dns dns;

--- a/src/com.docker.slirp/Makefile
+++ b/src/com.docker.slirp/Makefile
@@ -1,10 +1,15 @@
-build:
+build: src/depends.ml
 	ocaml pkg/pkg.ml build --vcs true --pinned true
+
+src/depends.ml: src/depends.ml.in
+	opam config subst src/depends.ml
+	sed -e 's/%%HOSTNET_PINNED%%/$(shell opam info hostnet -f pinned)/g' -i tmp src/depends.ml
 
 clean:
 	rm -rf _build
 	rm -f com.docker.slirp
 	rm -f com.docker.slirp.tgz
+	rm -f src/depends.ml
 
 stage:
 	mkdir -p _build/root/Contents/MacOS

--- a/src/com.docker.slirp/src/depends.ml.in
+++ b/src/com.docker.slirp/src/depends.ml.in
@@ -1,0 +1,3 @@
+let hostnet_version = "%{hostnet:version}%"
+let hostnet_pinned = "%%HOSTNET_PINNED%%"
+let uwt_version = "%{uwt:version}%"

--- a/src/com.docker.slirp/src/main.ml
+++ b/src/com.docker.slirp/src/main.ml
@@ -94,7 +94,9 @@ let main_t socket_path port_control_path vsock_path db_path nofile pcap debug =
   Log.info (fun f -> f "Setting handler to ignore all SIGPIPE signals");
   Sys.set_signal Sys.sigpipe Sys.Signal_ignore;
   set_nofile nofile;
-  Log.info (fun f -> f "vpnkit version %%VERSION%%");
+  Log.info (fun f -> f "vpnkit version %%VERSION%% with hostnet version %s %s and uwt version %s"
+    Depends.hostnet_version Depends.hostnet_pinned Depends.uwt_version
+  );
   Printexc.record_backtrace true;
 
   Lwt.async_exception_hook := (fun exn ->


### PR DESCRIPTION
To make understanding bug reports easier, the log output will now contain the versions of

- `uwt`
- `hvsock`
- `hostnet`

