### PR TITLE
hvsock.0.9.0: add not-yet-released patch

### DIFF
--- a/opam/win32/packages/dev/hvsock.0.9.0/files/send-recv.patch
+++ b/opam/win32/packages/dev/hvsock.0.9.0/files/send-recv.patch
@@ -1,0 +1,37 @@
+commit b06cf573dc62d7646ea8249ad225b4e51329a8af
+Author: David Scott <dave@recoil.org>
+Date:   Fri Jul 15 11:39:50 2016 +0100
+
+    hvsock: handle errors in send,recv where WSAGetLastError() == 0
+    
+    Although WSAGetLastError() should not be 0 when a socket error has
+    happened, with Hyper-V sockets I have seen this happen.
+    
+    This patch makes send and recv more robust by failing with a
+    Unix_error if `ret == SOCKET_ERROR` nomatter what the result of
+    `WSAGetLastError`.
+    
+    Signed-off-by: David Scott <dave@recoil.org>
+
+diff --git a/lib/hvsock_stubs.c b/lib/hvsock_stubs.c
+index e3146ef..2f3f85c 100644
+--- a/lib/hvsock_stubs.c
++++ b/lib/hvsock_stubs.c
+@@ -189,7 +189,7 @@ stub_hvsock_ba_recv(value fd, value val_buf, value val_ofs, value val_len)
+   if (ret == SOCKET_ERROR) err = WSAGetLastError();
+   caml_acquire_runtime_system();
+ 
+-  if (err) {
++  if (ret == SOCKET_ERROR) {
+     win32_maperr(err);
+     uerror("read", Nothing);
+   }
+@@ -212,7 +212,7 @@ stub_hvsock_ba_send(value fd, value val_buf, value val_ofs, value val_len)
+   if (ret == SOCKET_ERROR) err = WSAGetLastError();
+   caml_acquire_runtime_system();
+ 
+-  if (err) {
++  if (ret == SOCKET_ERROR) {
+     win32_maperr(err);
+     uerror("read", Nothing);
+   }

--- a/opam/win32/packages/dev/hvsock.0.9.0/opam
+++ b/opam/win32/packages/dev/hvsock.0.9.0/opam
@@ -5,7 +5,9 @@ license: "ISC"
 homepage: "https://github.com/djs55/ocaml-hvsock"
 dev-repo: "https://github.com/djs55/ocaml-hvsock.git"
 bug-reports: "https://github.com/djs55/ocaml-hvsock/issues"
-
+patches: [
+  "send-recv.patch"
+]
 build: [
   ["ocaml" "setup.ml" "-configure"]
   [make]


### PR DESCRIPTION
This prevents returning SOCKET_ERROR as a number of bytes in the case
that WSAGetLastError() returns 0 (which it has been observed to do with
Hyper-V sockets)

Signed-off-by: David Scott <dave.scott@docker.com>