### PR TITLE
Add a secondary dns forwarder IP

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ checkout:
   - opam/check-upstream.sh
 dependencies:
   override:
-  - brew install wget opam dylibbundler libffi
+  - brew install wget opam dylibbundler libffi pkg-config
   - make depends
   - make
   - make OSS-LICENSES

--- a/src/com.docker.slirp.exe/src/main.ml
+++ b/src/com.docker.slirp.exe/src/main.ml
@@ -135,6 +135,7 @@ let main_t socket_url port_control_url db_path dns pcap debug =
       let pcap = match pcap with None -> None | Some filename -> Some (filename, None) in
       Lwt.return { Slirp_stack.peer_ip = Ipaddr.V4.of_string_exn "192.168.65.2";
         local_ip = Ipaddr.V4.of_string_exn "192.168.65.1";
+        extra_dns_ip = Ipaddr.V4.of_string_exn "192.168.65.3";
         pcap_settings = Active_config.Value(pcap, never) }
   ) >>= fun stack ->
 

--- a/src/com.docker.slirp/src/main.ml
+++ b/src/com.docker.slirp/src/main.ml
@@ -128,6 +128,7 @@ let main_t socket_path port_control_path vsock_path db_path nofile pcap debug =
       let pcap = match pcap with None -> None | Some filename -> Some (filename, None) in
       Lwt.return { Slirp_stack.peer_ip = Ipaddr.V4.of_string_exn "192.168.65.2";
         local_ip = Ipaddr.V4.of_string_exn "192.168.65.1";
+        extra_dns_ip = Ipaddr.V4.of_string_exn "192.168.65.3";
         pcap_settings = Active_config.Value(pcap, never) }
   ) >>= fun stack ->
 

--- a/src/hostnet/lib/dns_forward.ml
+++ b/src/hostnet/lib/dns_forward.ml
@@ -113,8 +113,8 @@ let input ~ip ~udp ~src ~dst ~src_port buf =
       Log.debug (fun f -> f "DNS[%s] %s:%d <- %s %s" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns (parse_dns buffer)));
       remove_tid dns;
       Udp.write ~source_port:53 ~dest_ip:src ~dest_port:src_port udp buffer in
-
-    Socket.Datagram.input ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(dst, dst_port) ~payload:buf
+    let userdesc = "DNS[" ^ (tidstr_of_dns dns) ^ "]" in
+    Socket.Datagram.input ~userdesc ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(dst, dst_port) ~payload:buf ()
   | None ->
     Log.err (fun f -> f "DNS[%s] No upstream DNS server configured: dropping request" (tidstr_of_dns dns));
     Lwt.return_unit

--- a/src/hostnet/lib/dns_forward.ml
+++ b/src/hostnet/lib/dns_forward.ml
@@ -26,30 +26,7 @@ let tidstr_of_dns dns =
 
 module Make(Ip: V1_LWT.IPV4) (Udp:V1_LWT.UDPV4) (Resolv_conf: Sig.RESOLV_CONF) (Socket: Sig.SOCKETS) (Time: V1_LWT.TIME) = struct
 
-type transaction = {
-  mutable resolvers : (Ipaddr.t * int) list;
-  mutable used_resolvers : (Ipaddr.t * int) list;
-  mutable last_use: float;
-}
-
-let table = Hashtbl.create 7
-
-let start_reaper () =
-  let rec loop () =
-    Time.sleep 60.
-    >>= fun () ->
-    let snapshot = Hashtbl.copy table in
-    let now = Unix.gettimeofday () in
-    Hashtbl.iter (fun k trec ->
-      if now -. trec.last_use > 60. then begin
-        Log.debug (fun f -> f "DNS[%04x] Expiring DNS trec" k);
-        Hashtbl.remove table k
-      end
-    ) snapshot;
-    loop () in
-  loop ()
-
-let input ~ip ~udp ~src ~dst ~src_port buf =
+let input ~secondary ~ip ~udp ~src ~dst ~src_port buf =
   if List.mem dst (Ip.get_ip ip) then begin
 
   let src_str = Ipaddr.V4.to_string src in
@@ -57,61 +34,23 @@ let input ~ip ~udp ~src ~dst ~src_port buf =
 
   let dns = parse_dns buf in
 
-  let remove_tid dns =
-    match dns with
-    | (_, None) -> ()
-    | (_, Some { Dns.Packet.id; _ }) -> Hashtbl.remove table id in
-
   Log.debug (fun f -> f "DNS[%s] %s:%d -> %s %s" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns dns));
 
-  match dns with
-  | (_, None) -> begin
-    Resolv_conf.get ()
-    >>= function
-    | r::_ -> Lwt.return_some r
-    | _ -> Lwt.return_none
-  end
-  | (_, Some { Dns.Packet.id = tid; _ }) -> begin
-    Lwt.catch
-      (fun () ->
-        let trec = Hashtbl.find table tid in
-        let r, rs, urs = match trec.resolvers with
-          | r::rs -> (r,rs,r::trec.used_resolvers)
-          | _ -> match List.rev trec.used_resolvers with
-            | r::rs -> (r,rs,[])
-            | _  -> assert false (* resolvers and used_resolvers cannot both be empty *)
-        in
-        Log.debug (fun f -> f "DNS[%s] Retry" (tidstr_of_dns dns));
-        trec.resolvers <- rs;
-        trec.used_resolvers <- urs;
-        trec.last_use <- Unix.gettimeofday ();
-        Lwt.return_some r
-      )
-      (function
-      | Not_found -> begin
-         (* Re-read /etc/resolv.conf on every request. This ensures that
-            changes to DNS on sleep/resume or switching networks are reflected
-            immediately. The file is very small, and parsing it shouldn't be
-            too slow. *)
-        Resolv_conf.get ()
-        >>= function
-        | r::rs -> begin
-          let last_use = Unix.gettimeofday () in
-          let trec = { resolvers = rs; used_resolvers = r :: []; last_use } in
-          Hashtbl.replace table tid trec;
-          Lwt.return_some r
-        end
-        | _ -> Lwt.return_none
-      end
-      | ex -> Lwt.fail ex
-      )
-  end;
+  Resolv_conf.get ()
+
+  >>= ( function
+  | _::sec::_ when secondary -> Lwt.return_some ("secondary", sec)
+  | pri::_::_ when not secondary -> Lwt.return_some ("primary", pri)
+  (* These two could be collapsed, but for the desire to differentiate in the logging *)
+  | pri::_ when secondary -> Lwt.return_some ("secondary(wrapped)", pri)
+  | pri::_ when not secondary -> Lwt.return_some ("primary(sole)", pri)
+  | _ -> Lwt.return_none )
+
   >>= function
-  | Some (dst, dst_port) ->
-    Log.debug (fun f -> f "DNS[%s] Forwarding to %s" (tidstr_of_dns dns) (Ipaddr.to_string dst));
+  | Some (dst_str, (dst, dst_port)) ->
+    Log.debug (fun f -> f "DNS[%s] Forwarding to %s (%s)" (tidstr_of_dns dns) (Ipaddr.to_string dst) dst_str);
     let reply buffer =
-      Log.debug (fun f -> f "DNS[%s] %s:%d <- %s %s" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns (parse_dns buffer)));
-      remove_tid dns;
+      Log.debug (fun f -> f "DNS[%s] %s:%d <- %s (%s)" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns (parse_dns buffer)));
       Udp.write ~source_port:53 ~dest_ip:src ~dest_port:src_port udp buffer in
     let userdesc = "DNS[" ^ (tidstr_of_dns dns) ^ "]" in
     Socket.Datagram.input ~userdesc ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(dst, dst_port) ~payload:buf ()

--- a/src/hostnet/lib/dns_forward.mli
+++ b/src/hostnet/lib/dns_forward.mli
@@ -4,6 +4,5 @@ module Make
     (Resolv_conv: Sig.RESOLV_CONF)
     (Socket: Sig.SOCKETS)
     (Time: V1_LWT.TIME) : sig
-  val start_reaper: unit -> unit Lwt.t
-  val input: ip:Ip.t -> udp:Udp.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
+  val input: secondary:bool -> ip:Ip.t -> udp:Udp.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
 end

--- a/src/hostnet/lib/host_lwt_unix.ml
+++ b/src/hostnet/lib/host_lwt_unix.ml
@@ -111,7 +111,7 @@ module Datagram = struct
     (if Hashtbl.mem table (src, src_port, dst, dst_port) then begin
         Lwt.return (Some (Hashtbl.find table (src, src_port, dst, dst_port)))
       end else begin
-       let description = Ipaddr.to_string src ^ ":" ^ (string_of_int src_port) ^ "-" ^ (Ipaddr.to_string dst) ^ ":" ^ (string_of_int dst_port) in
+       let description = String.concat "" [Ipaddr.to_string src; ":"; string_of_int src_port; "-"; Ipaddr.to_string dst; ":"; string_of_int dst_port] in
        if Ipaddr.compare dst Ipaddr.(V4 V4.broadcast) = 0 then begin
          Log.debug (fun f -> f "Socket.Datagram.input %s: ignoring broadcast packet" description);
          Lwt.return None

--- a/src/hostnet/lib/host_lwt_unix.ml
+++ b/src/hostnet/lib/host_lwt_unix.ml
@@ -106,12 +106,15 @@ module Datagram = struct
       loop () in
     loop ()
 
-  let input ~reply ~src:(src, src_port) ~dst:(dst, dst_port) ~payload =
+  let input ?userdesc ~reply ~src:(src, src_port) ~dst:(dst, dst_port) ~payload () =
     let remote_sockaddr = Unix.ADDR_INET(Unix.inet_addr_of_string @@ Ipaddr.to_string dst, dst_port) in
     (if Hashtbl.mem table (src, src_port, dst, dst_port) then begin
         Lwt.return (Some (Hashtbl.find table (src, src_port, dst, dst_port)))
       end else begin
-       let description = String.concat "" [Ipaddr.to_string src; ":"; string_of_int src_port; "-"; Ipaddr.to_string dst; ":"; string_of_int dst_port] in
+       let userdesc = match userdesc with
+         | None -> ""
+         | Some x -> String.concat "" [ " ("; x; ")" ] in
+       let description = String.concat "" [ Ipaddr.to_string src; ":"; string_of_int src_port; "-"; Ipaddr.to_string dst; ":"; string_of_int dst_port; userdesc ] in
        if Ipaddr.compare dst Ipaddr.(V4 V4.broadcast) = 0 then begin
          Log.debug (fun f -> f "Socket.Datagram.input %s: ignoring broadcast packet" description);
          Lwt.return None

--- a/src/hostnet/lib/host_uwt.ml
+++ b/src/hostnet/lib/host_uwt.ml
@@ -86,7 +86,7 @@ module Sockets = struct
       (if Hashtbl.mem table (src, src_port, dst, dst_port) then begin
           Lwt.return (Some (Hashtbl.find table (src, src_port, dst, dst_port)))
         end else begin
-         let description = Ipaddr.to_string src ^ ":" ^ (string_of_int src_port) ^ "-" ^ (Ipaddr.to_string dst) ^ ":" ^ (string_of_int dst_port) in
+         let description = String.concat "" [Ipaddr.to_string src; ":"; string_of_int src_port; "-"; Ipaddr.to_string dst; ":"; string_of_int dst_port] in
          if Ipaddr.compare dst Ipaddr.(V4 V4.broadcast) = 0 then begin
            Log.debug (fun f -> f "Socket.Datagram.input %s: ignoring broadcast packet" description);
            Lwt.return None

--- a/src/hostnet/lib/host_uwt.ml
+++ b/src/hostnet/lib/host_uwt.ml
@@ -82,11 +82,14 @@ module Sockets = struct
         loop () in
       loop ()
 
-    let input ~reply ~src:(src, src_port) ~dst:(dst, dst_port) ~payload =
+    let input ?userdesc ~reply ~src:(src, src_port) ~dst:(dst, dst_port) ~payload () =
       (if Hashtbl.mem table (src, src_port, dst, dst_port) then begin
           Lwt.return (Some (Hashtbl.find table (src, src_port, dst, dst_port)))
         end else begin
-         let description = String.concat "" [Ipaddr.to_string src; ":"; string_of_int src_port; "-"; Ipaddr.to_string dst; ":"; string_of_int dst_port] in
+         let userdesc = match userdesc with
+           | None -> ""
+           | Some x -> String.concat "" [ " ("; x; ")" ] in
+         let description = String.concat "" [ Ipaddr.to_string src; ":"; string_of_int src_port; "-"; Ipaddr.to_string dst; ":"; string_of_int dst_port; userdesc ] in
          if Ipaddr.compare dst Ipaddr.(V4 V4.broadcast) = 0 then begin
            Log.debug (fun f -> f "Socket.Datagram.input %s: ignoring broadcast packet" description);
            Lwt.return None

--- a/src/hostnet/lib/sig.ml
+++ b/src/hostnet/lib/sig.ml
@@ -46,7 +46,7 @@ module type DATAGRAM = sig
 
   type reply = Cstruct.t -> unit Lwt.t
 
-  val input: reply:reply -> src:address -> dst:address -> payload:Cstruct.t -> unit Lwt.t
+  val input: ?userdesc:string -> reply:reply -> src:address -> dst:address -> payload:Cstruct.t -> unit -> unit Lwt.t
 
   module Udp: sig
     type server

--- a/src/hostnet/lib/slirp.ml
+++ b/src/hostnet/lib/slirp.ml
@@ -134,7 +134,7 @@ let connect x peer_ip local_ip =
                                        length
                                    );
                           let reply buf = Tcpip_stack.UDPV4.writev ~source_ip:dst ~source_port:dst_port ~dest_ip:src ~dest_port:src_port (Tcpip_stack.udpv4 s) [ buf ] in
-                          Socket.Datagram.input ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(Ipaddr.V4 dst, dst_port) ~payload
+                          Socket.Datagram.input ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(Ipaddr.V4 dst, dst_port) ~payload ()
                         end
                         else if for_us && dst_port = 123 then begin
                           (* port 123 is special -- proxy these requests to
@@ -143,7 +143,7 @@ let connect x peer_ip local_ip =
                           let localhost = Ipaddr.V4.localhost in
                           Log.debug (fun f -> f "UDP/123 request from port %d -- sending it to %a:%d" src_port Ipaddr.V4.pp_hum localhost dst_port);
                           let reply buf = Tcpip_stack.UDPV4.writev ~source_ip:local_ip ~source_port:dst_port ~dest_ip:src ~dest_port:src_port (Tcpip_stack.udpv4 s) [ buf ] in
-                          Socket.Datagram.input ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(Ipaddr.V4 localhost, dst_port) ~payload
+                          Socket.Datagram.input ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(Ipaddr.V4 localhost, dst_port) ~payload ()
                         end else Lwt.return_unit
                       end
                     | _ -> Lwt.return_unit

--- a/src/hostnet/lib/slirp.ml
+++ b/src/hostnet/lib/slirp.ml
@@ -123,7 +123,7 @@ let connect x peer_ip local_ip =
                         Tcpip_stack.IPV4.writev (Tcpip_stack.ipv4 s) ethernet_ip_hdr [ reply ];
                       end else begin
                         let payload = Cstruct.sub udp Wire_structs.sizeof_udp (length - Wire_structs.sizeof_udp) in
-                        let for_us = Ipaddr.V4.compare dst local_ip == 0 in
+                        let for_us = Ipaddr.V4.compare dst local_ip = 0 in
                         (* We handle DNS on port 53 ourselves, see [listen_udpv4] above *)
                         (* ... but if it's going to an external IP then we treat it like all other
                            UDP and NAT it *)
@@ -136,7 +136,7 @@ let connect x peer_ip local_ip =
                           let reply buf = Tcpip_stack.UDPV4.writev ~source_ip:dst ~source_port:dst_port ~dest_ip:src ~dest_port:src_port (Tcpip_stack.udpv4 s) [ buf ] in
                           Socket.Datagram.input ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(Ipaddr.V4 dst, dst_port) ~payload
                         end
-                        else if for_us && dst_port == 123 then begin
+                        else if for_us && dst_port = 123 then begin
                           (* port 123 is special -- proxy these requests to
                              our localhost address for the local OSX ntp
                              listener to respond to *)
@@ -153,7 +153,7 @@ let connect x peer_ip local_ip =
             Tcpip_stack.listen_tcpv4_flow s ~on_flow_arrival:(
               fun ~src:(src_ip, src_port) ~dst:(dst_ip, dst_port) ->
 
-                let for_us src_ip = Ipaddr.V4.compare src_ip local_ip == 0 in
+                let for_us src_ip = Ipaddr.V4.compare src_ip local_ip = 0 in
                 ( if for_us src_ip && src_port = 53 then begin
                     Resolv_conf.get () (* re-read /etc/resolv.conf *)
                     >>= function

--- a/src/hostnet/lib/slirp.mli
+++ b/src/hostnet/lib/slirp.mli
@@ -9,6 +9,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Resolv_conv: Sig.RESOLV_C
   type config = {
     peer_ip: Ipaddr.V4.t;
     local_ip: Ipaddr.V4.t;
+    extra_dns_ip: Ipaddr.V4.t;
     pcap_settings: pcap Active_config.values;
   }
   (** A slirp TCP/IP stack ready to accept connections *)

--- a/src/hostnet/lib/tcpip_stack.mli
+++ b/src/hostnet/lib/tcpip_stack.mli
@@ -4,9 +4,9 @@ include Sig.TCPIP
 type configuration
 
 val make: client_macaddr:Macaddr.t -> server_macaddr:Macaddr.t
-  -> peer_ip: Ipaddr.V4.t -> local_ip:Ipaddr.V4.t -> configuration
+  -> peer_ip: Ipaddr.V4.t -> local_ip:Ipaddr.V4.t -> extra_dns_ip:Ipaddr.V4.t -> configuration
 
 val connect:
   config:configuration -> Vmnet.t
-  -> [ `Ok of t | `Error of [ `Msg of string ] ] Lwt.t
+  -> [ `Ok of t * (ipv4 * udpv4) | `Error of [ `Msg of string ] ] Lwt.t
 end

--- a/src/hostnet/lib_test/main.ml
+++ b/src/hostnet/lib_test/main.ml
@@ -63,6 +63,7 @@ let config =
   {
     Slirp_stack.peer_ip = Ipaddr.V4.of_string_exn "192.168.65.2";
     local_ip = Ipaddr.V4.of_string_exn "192.168.65.1";
+    extra_dns_ip = Ipaddr.V4.of_string_exn "192.168.65.3";
     pcap_settings = Active_config.Value(None, never);
   }
 


### PR DESCRIPTION
The second commit is the interesting one. Its commit log:

    In #38 I attempted to address the problem of flakey upstream DNS by
    round-robinning DNS retries (detected via the DNS ID field), replicating the
    fallback behaviour a client which has been given multiple entries in
    resolv.conf despite only providing then with a single entry.
    
    However this turns out to have been insufficient because not all client side
    resolvers reuse the DNS ID on retry, so we do not see those retries as such and
    send them to the primary upstream DNS a second time.
    
    To address this create a second IP end point (on the same underlying device, so
    essentially an IP alias)  and expose it to the client (via DHCP) as a second
    DNS server which forwards to the secondary upstream DNS server and revert most
    of #38 such that for the existing local IP we always forward to the primary
    upstream DNS server (if the host only has a single DNS server configured then
    both end points will go to the that one).
    
    Third and subsequent host DNS servers are ignored.
    
    This has only been tested on Mac, but given an implementation of Resolv_conf
    which returns 2 (or more) DNS end points this should work for Windows too.
    
    This second IP address is bolted onto the side in what appears to be a slightly
    odd way. However I think it is consistent with the direction (AIUI) we intend
    to be moving which is to remove the use of `Tcpip_stack_direct` (since we
    aren't really a TCP/IP "endpoint") in favour of a lower level approach (based
    on the newer Marshal/Unmarshal interfaces in mirage-tcpip rather than even more
    open coding). Currently mirage-tcpip does not support aliases (second IPs) on a
    device, so going the route of creating a second full stack would have required
    an entire extra network device be exposed to the client.
