### PR TITLE
Allow the max concurrent forwarded connections to be configured

### DIFF
--- a/src/com.docker.slirp.exe/src/connect.ml
+++ b/src/com.docker.slirp.exe/src/connect.ml
@@ -5,20 +5,20 @@ let src =
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let hvsockaddr = ref None
-
-let set_port_forward_addr x = hvsockaddr := Some x
-
-let max_connections = ref None
-
-let set_max_connections x = max_connections := x
-
 module Make(Time: V1_LWT.TIME)(Main: Lwt_hvsock.MAIN) = struct
   include Flow_lwt_hvsock_shutdown.Make(Time)(Main)
 
   open Lwt.Infix
 
   type address = unit
+
+  let hvsockaddr = ref None
+
+  let set_port_forward_addr x = hvsockaddr := Some x
+
+  let max_connections = ref None
+
+  let set_max_connections x = max_connections := x
 
   let active_connections = ref 0
 

--- a/src/com.docker.slirp.exe/src/connect.ml
+++ b/src/com.docker.slirp.exe/src/connect.ml
@@ -9,6 +9,10 @@ let hvsockaddr = ref None
 
 let set_port_forward_addr x = hvsockaddr := Some x
 
+let max_connections = ref None
+
+let set_max_connections x = max_connections := x
+
 module Make(Time: V1_LWT.TIME)(Main: Lwt_hvsock.MAIN) = struct
   include Flow_lwt_hvsock_shutdown.Make(Time)(Main)
 
@@ -16,11 +20,25 @@ module Make(Time: V1_LWT.TIME)(Main: Lwt_hvsock.MAIN) = struct
 
   type address = unit
 
+  let active_connections = ref 0
+
+  let close flow =
+    decr active_connections;
+    close flow
+
   let connect () = match !hvsockaddr with
     | None ->
       Log.err (fun f -> f "Please set a Hyper-V socket address for port forwarding");
       failwith "Hyper-V socket forwarding not initialised"
     | Some sockaddr ->
+      ( match !max_connections with
+        | Some m when !active_connections >= m ->
+          Log.err (fun f -> f "exceeded maximum number of forwarded connections (%d)" m);
+          Lwt.fail End_of_file
+        | _ ->
+          incr active_connections;
+          Lwt.return_unit )
+      >>= fun () ->
       let fd = Hvsock.create () in
       Hvsock.connect fd sockaddr
       >>= fun () ->

--- a/src/com.docker.slirp.exe/src/connect.mli
+++ b/src/com.docker.slirp.exe/src/connect.mli
@@ -1,7 +1,9 @@
 open Hostnet
 
-module Make(Time: V1_LWT.TIME)(Main: Lwt_hvsock.MAIN): Sig.Connector
+module Make(Time: V1_LWT.TIME)(Main: Lwt_hvsock.MAIN): sig
+  include Sig.Connector
 
-val set_port_forward_addr: Hvsock.sockaddr -> unit
+  val set_port_forward_addr: Hvsock.sockaddr -> unit
 
-val set_max_connections: int option -> unit
+  val set_max_connections: int option -> unit
+end

--- a/src/com.docker.slirp.exe/src/connect.mli
+++ b/src/com.docker.slirp.exe/src/connect.mli
@@ -3,3 +3,5 @@ open Hostnet
 module Make(Time: V1_LWT.TIME)(Main: Lwt_hvsock.MAIN): Sig.Connector
 
 val set_port_forward_addr: Hvsock.sockaddr -> unit
+
+val set_max_connections: int option -> unit

--- a/src/com.docker.slirp.exe/src/main.ml
+++ b/src/com.docker.slirp.exe/src/main.ml
@@ -34,6 +34,7 @@ let hvsock_addr_of_uri ~default_serviceid uri =
 
 module Main(Host: Sig.HOST) = struct
 
+module Connect = Connect.Make(Host.Time)(Host.Main)
 module Bind = Host.Sockets
 module Config = Active_config.Make(Host.Time)(Host.Sockets.Stream.Unix)
 
@@ -64,7 +65,7 @@ let hvsock_connect_forever url sockaddr callback =
   Log.debug (fun f -> f "Waiting for connections on socket %s" url);
   aux ()
 
-module Forward = Forward.Make(Connect.Make(Host.Time)(Host.Main))(Host.Sockets)
+module Forward = Forward.Make(Connect)(Host.Sockets)
 
 let start_port_forwarding port_control_url max_connections =
   Log.info (fun f -> f "starting port_forwarding port_control_url:%s max_connections:%s" port_control_url (match max_connections with None -> "None" | Some x -> "Some " ^ (string_of_int x)));

--- a/src/com.docker.slirp/src/connect.ml
+++ b/src/com.docker.slirp/src/connect.ml
@@ -15,13 +15,32 @@ module Make(Socket: Sig.SOCKETS) = struct
 
   let vsock_path = ref (home / "Library/Containers/com.docker.docker/Data/@connect")
 
+  let max_connections = ref None
+
+  let set_max_connections x = max_connections := x
+
   include Socket.Stream.Unix
+
+  let active_connections = ref 0
+
+  let close flow =
+    decr active_connections;
+    close flow
 
   let connect () =
     let open Lwt.Infix in
+    ( match !max_connections with
+      | Some m when !active_connections >= m ->
+        Log.err (fun f -> f "exceeded maximum number of forwarded connections (%d)" m);
+        Lwt.fail End_of_file
+      | _ ->
+        incr active_connections;
+        Lwt.return_unit )
+    >>= fun () ->
     connect (!vsock_path)
     >>= function
     | `Error (`Msg msg) ->
+      decr active_connections;
       Log.err (fun f -> f "vsock connect write got %s" msg);
       Lwt.fail (Failure msg)
     | `Ok flow ->

--- a/src/com.docker.slirp/src/connect.ml
+++ b/src/com.docker.slirp/src/connect.ml
@@ -30,10 +30,14 @@ module Make(Socket: Sig.SOCKETS) = struct
       >>= function
       | `Eof ->
         Log.err (fun f -> f "vsock connect write got Eof");
+        close flow
+        >>= fun () ->
         Lwt.fail End_of_file
       | `Error e ->
         let msg = error_message e in
         Log.err (fun f -> f "vsock connect write got %s" msg);
+        close flow
+        >>= fun () ->
         Lwt.fail (Failure msg)
       | `Ok () ->
         Lwt.return flow

--- a/src/com.docker.slirp/src/connect.mli
+++ b/src/com.docker.slirp/src/connect.mli
@@ -3,5 +3,7 @@ open Hostnet
 module Make(Socket: Sig.SOCKETS): sig
   include Sig.Connector
 
+  val set_max_connections: int option -> unit
+
   val vsock_path: string ref
 end


### PR DESCRIPTION
Every forwarded connection consumes resources:

- the accepted connection on the host
- the `virtio-vsock` or `AF_HYPERV` forwarded connection to the VM
- the accepted connection in the VM
- the forwarded connection in the VM

We've already bumped the maximum number of fds in various places, so now the bottleneck is the `virtio-vsock` or `AF_HYPERV` connection to the VM. We would like to avoid hitting this limit because it will cause the docker socket forward to fail too.

This PR adds code to support an upper limit to the number of supported concurrent connections forwarded into the VM. By default there is no limit, but a command-line `--max-connections` allows it to be set to some concrete value. When the limit is hit, incoming connections are closed, matching the behaviour of `libuv` when it runs out of resources.

Note this PR only affects the code where connections are forwarded *into* the VM. Connections from the VM to the outside are unchanged: such outgoing connections are only limited by the maximum number of file descriptors in the `com.docker.slirp` process since they are multiplexed over a single virtual ethernet connection to the VM.

This PR also fixes a connection leak in some Mac error paths.