### PR TITLE
Avoid some scary errors

### DIFF
--- a/src/hostnet/lib/host_uwt.ml
+++ b/src/hostnet/lib/host_uwt.ml
@@ -264,7 +264,7 @@ module Sockets = struct
         try
           if not closed then Uwt.Tcp.shutdown fd else Lwt.return ()
         with
-        | Unix.Unix_error(Unix.ENOTCONN, _, _) -> Lwt.return ()
+        | Uwt.Uwt_error(Uwt.ENOTCONN, _, _) -> Lwt.return ()
         | e ->
           Log.err (fun f -> f "Socket.TCPV4.shutdown_write %s: caught %s returning Eof" description (Printexc.to_string e));
           Lwt.return ()
@@ -472,7 +472,7 @@ module Sockets = struct
         try
           if not closed then Uwt.Pipe.shutdown fd else Lwt.return ()
         with
-        | Unix.Unix_error(Unix.ENOTCONN, _, _) -> Lwt.return ()
+        | Uwt.Uwt_error(Uwt.ENOTCONN, _, _) -> Lwt.return ()
         | e ->
           Log.err (fun f -> f "Socket.Pipe.shutdown_write %s: caught %s returning Eof" description (Printexc.to_string e));
           Lwt.return ()


### PR DESCRIPTION
Avoid logging an error when

- a `shutdown_write` encounters a `Uwt.Uwt_error` (previously we expected `Unix.Unix_error` but `uwt` uses different exceptions to `unix`)
- a `write` encounters an `EPIPE`: this means the remote has closed and we've only just found out