### PR TITLE
Filter IPv6 resolvers from /etc/resolv.conf until we have V6 forwarding

### DIFF
--- a/src/com.docker.slirp/src/resolv_conf.ml
+++ b/src/com.docker.slirp/src/resolv_conf.ml
@@ -33,6 +33,10 @@ module Make(Files: Sig.FILES) = struct
                );
       current_dns := !default_dns
 
+  let all_ipv4_servers config =
+     all_servers config |>
+     List.filter (fun (ip,_) -> match ip with Ipaddr.V4 _ -> true |_ -> false)
+
   let get () =
     match !current_dns with
     | _ :: _ as dns -> Lwt.return dns
@@ -55,6 +59,6 @@ module Make(Files: Sig.FILES) = struct
                 | _ -> acc
               end
           ) [] lines in
-        Lwt.return (all_servers config)
+        Lwt.return (all_ipv4_servers config)
 
 end


### PR DESCRIPTION
We currently read all the 'nameserver' entries out of `resolv.conf`,
including the IPv6 and IPv4 entries.  However, the forwarding logic
in slirp does not handle the IPv6 case yet (primarily due to a lack
of testing), and so a user with an IPv6 resolver as the first entry
will have forwarding failures.

This patch filters for IPv4 resolvers to work around the issue so that
if the `resolv.conf` has at least one IPv4 server, it will get picked
up and used.  This is the minimal patch: we do need to support IPv6
forwarding as well but that will be a bigger change.

Reported in docker/for-mac#9.

Signed-off-by: Anil Madhavapeddy <anil@docker.com>