### PR TITLE
More DNS fixes

### DIFF
--- a/src/hostnet/lib/dns_forward.ml
+++ b/src/hostnet/lib/dns_forward.ml
@@ -30,6 +30,15 @@ let only_ipv4 servers =
     | _ -> false
   ) servers
 
+let choose_server ~secondary all =
+  match only_ipv4 all, secondary with
+  | _   :: sec :: _  , true  -> Some ("secondary",          sec)
+  | pri :: _   :: _  , false -> Some ("primary",            pri)
+  (* These two could be collapsed, but for the desire to differentiate in the logging *)
+  | pri :: _         , true  -> Some ("secondary(wrapped)", pri)
+  | pri :: _         , false -> Some ("primary(sole)",      pri)
+  | _                        -> None
+
 module Make(Ip: V1_LWT.IPV4) (Udp:V1_LWT.UDPV4) (Resolv_conf: Sig.RESOLV_CONF) (Socket: Sig.SOCKETS) (Time: V1_LWT.TIME) = struct
 
 let input ~secondary ~ip ~udp ~src ~dst ~src_port buf =
@@ -44,15 +53,7 @@ let input ~secondary ~ip ~udp ~src ~dst ~src_port buf =
 
   Resolv_conf.get ()
   >>= fun all ->
-  ( match only_ipv4 all with
-  | _::sec::_ when secondary -> Lwt.return_some ("secondary", sec)
-  | pri::_::_ when not secondary -> Lwt.return_some ("primary", pri)
-  (* These two could be collapsed, but for the desire to differentiate in the logging *)
-  | pri::_ when secondary -> Lwt.return_some ("secondary(wrapped)", pri)
-  | pri::_ when not secondary -> Lwt.return_some ("primary(sole)", pri)
-  | _ -> Lwt.return_none )
-
-  >>= function
+  match choose_server ~secondary all with
   | Some (dst_str, (dst, dst_port)) ->
     Log.debug (fun f -> f "DNS[%s] Forwarding to %s (%s)" (tidstr_of_dns dns) (Ipaddr.to_string dst) dst_str);
     let reply buffer =

--- a/src/hostnet/lib/dns_forward.mli
+++ b/src/hostnet/lib/dns_forward.mli
@@ -6,3 +6,8 @@ module Make
     (Time: V1_LWT.TIME) : sig
   val input: secondary:bool -> ip:Ip.t -> udp:Udp.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
 end
+
+val choose_server: secondary:bool -> (Ipaddr.t * int) list -> (string * (Ipaddr.t * int)) option
+(** [choose_server secondary servers] chooses an upstream server to use from
+    [servers] depending on whether the request arrived on the [secondary] IP
+    or not. Also returns a short descriptive string to include in the logs. *)


### PR DESCRIPTION

- filter IPv6 DNS servers in the core library so it's easier to test; and to ensure covers both the `/etc/resolv.conf` path and the DNS-servers-in-database-keys path
- share the same primary/secondary server choosing logic between UDP and TCP: this fixes TCP DNS to the secondary IP by forwarding it to the second nameserver correctly