### PR TITLE
Add some TCP loopback connection tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ depends:
 	# Don't run all the unit tests of all upstream packages in the universe for speed
 	$(OPAMFLAGS) opam install $(shell ls -1 $(OPAM_REPO)/packages/upstream) -y
 	# Please do run the unit tests for our packages
-	$(OPAMFLAGS) opam install --deps-only slirp -y -t
+	$(OPAMFLAGS) OPAMVERBOSE=1 opam install --deps-only slirp -y -t
 
 com.docker.slirp.tgz:
 	cd src/com.docker.slirp && $(OPAMFLAGS) opam config exec -- $(MAKE) build stage

--- a/src/hostnet/_oasis
+++ b/src/hostnet/_oasis
@@ -32,5 +32,5 @@ Executable test
 
 Test test
   Run$:               flag(tests)
-  Command:            $test
+  Command:            $test -q
   WorkingDirectory:   lib_test


### PR DESCRIPTION
These tests set up a local server and then use the Mirage client to connect and send 1KiB, 1MiB and 1GiB through each connection, with up to 32 separate connections.

These work fine on OSX, but they're untested on Windows. There might be a problem running them from the CI on appveyor because of the Windows firewall -- if the tests timeout this is probably why.