### PR TITLE
Support more than 2 physical DNS servers

### DIFF
--- a/src/com.docker.slirp/src/main.ml
+++ b/src/com.docker.slirp/src/main.ml
@@ -199,7 +199,10 @@ let main_t socket_url port_control_url max_connections vsock_path db_path dns pc
     let pcap = match pcap with None -> None | Some filename -> Some (filename, None) in
     { Slirp.peer_ip = Ipaddr.V4.of_string_exn "192.168.65.2";
       local_ip = Ipaddr.V4.of_string_exn "192.168.65.1";
-      extra_dns_ip = Ipaddr.V4.of_string_exn "192.168.65.3";
+      extra_dns_ip = List.map Ipaddr.V4.of_string_exn [
+        "192.168.65.3"; "192.168.65.4"; "192.168.65.5"; "192.168.65.6";
+        "192.168.65.7"; "192.168.65.8"; "192.168.65.9"; "192.168.65.10";
+      ];
       pcap_settings = Active_config.Value(pcap, never) } in
 
   let config = match db_path with

--- a/src/hostnet/_oasis
+++ b/src/hostnet/_oasis
@@ -20,7 +20,7 @@ Library hostnet
     ppx_sexp_conv, pcap-format, mirage-console.unix, tcpip.ethif,
     tcpip.arpv4, tcpip.ipv4, tcpip.udp, tcpip.tcp, tcpip.stack-direct,
     charrua-core.server, dns, dns.lwt, ofs, uwt, uwt.ext, uwt.preemptive,
-    lwt.preemptive, threads
+    lwt.preemptive, threads, astring
 
 Executable test
   Path: lib_test

--- a/src/hostnet/lib/dns_forward.ml
+++ b/src/hostnet/lib/dns_forward.ml
@@ -39,7 +39,7 @@ let choose_server ~nth all =
 
 module Make(Ip: V1_LWT.IPV4) (Udp:V1_LWT.UDPV4) (Resolv_conf: Sig.RESOLV_CONF) (Socket: Sig.SOCKETS) (Time: V1_LWT.TIME) = struct
 
-let input ~secondary ~udp ~src ~dst ~src_port buf =
+let input ~nth ~udp ~src ~dst ~src_port buf =
   let src_str = Ipaddr.V4.to_string src in
   let dst_str = Ipaddr.V4.to_string dst in
 
@@ -49,7 +49,7 @@ let input ~secondary ~udp ~src ~dst ~src_port buf =
 
   Resolv_conf.get ()
   >>= fun all ->
-  match choose_server ~nth:(if secondary then 1 else 0) all with
+  match choose_server ~nth all with
   | Some (dst_str, (dst, dst_port)) ->
     Log.debug (fun f -> f "DNS[%s] Forwarding to %s (%s)" (tidstr_of_dns dns) (Ipaddr.to_string dst) dst_str);
     let reply buffer =

--- a/src/hostnet/lib/dns_forward.ml
+++ b/src/hostnet/lib/dns_forward.ml
@@ -41,9 +41,7 @@ let choose_server ~secondary all =
 
 module Make(Ip: V1_LWT.IPV4) (Udp:V1_LWT.UDPV4) (Resolv_conf: Sig.RESOLV_CONF) (Socket: Sig.SOCKETS) (Time: V1_LWT.TIME) = struct
 
-let input ~secondary ~ip ~udp ~src ~dst ~src_port buf =
-  if List.mem dst (Ip.get_ip ip) then begin
-
+let input ~secondary ~udp ~src ~dst ~src_port buf =
   let src_str = Ipaddr.V4.to_string src in
   let dst_str = Ipaddr.V4.to_string dst in
 
@@ -64,5 +62,4 @@ let input ~secondary ~ip ~udp ~src ~dst ~src_port buf =
   | None ->
     Log.err (fun f -> f "DNS[%s] No upstream DNS server configured: dropping request" (tidstr_of_dns dns));
     Lwt.return_unit
-  end else Lwt.return_unit
 end

--- a/src/hostnet/lib/dns_forward.mli
+++ b/src/hostnet/lib/dns_forward.mli
@@ -7,7 +7,7 @@ module Make
   val input: secondary:bool -> udp:Udp.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
 end
 
-val choose_server: secondary:bool -> (Ipaddr.t * int) list -> (string * (Ipaddr.t * int)) option
-(** [choose_server secondary servers] chooses an upstream server to use from
-    [servers] depending on whether the request arrived on the [secondary] IP
-    or not. Also returns a short descriptive string to include in the logs. *)
+val choose_server: nth:int -> (Ipaddr.t * int) list -> (string * (Ipaddr.t * int)) option
+(** [choose_server nth servers] chooses an upstream server to use from
+    [servers]. The choice depends on which virtual server IP received the request
+    (nth).  Also returns a short descriptive string to include in the logs. *)

--- a/src/hostnet/lib/dns_forward.mli
+++ b/src/hostnet/lib/dns_forward.mli
@@ -4,7 +4,7 @@ module Make
     (Resolv_conv: Sig.RESOLV_CONF)
     (Socket: Sig.SOCKETS)
     (Time: V1_LWT.TIME) : sig
-  val input: secondary:bool -> udp:Udp.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
+  val input: nth:int -> udp:Udp.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
 end
 
 val choose_server: nth:int -> (Ipaddr.t * int) list -> (string * (Ipaddr.t * int)) option

--- a/src/hostnet/lib/dns_forward.mli
+++ b/src/hostnet/lib/dns_forward.mli
@@ -4,7 +4,7 @@ module Make
     (Resolv_conv: Sig.RESOLV_CONF)
     (Socket: Sig.SOCKETS)
     (Time: V1_LWT.TIME) : sig
-  val input: secondary:bool -> ip:Ip.t -> udp:Udp.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
+  val input: secondary:bool -> udp:Udp.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
 end
 
 val choose_server: secondary:bool -> (Ipaddr.t * int) list -> (string * (Ipaddr.t * int)) option

--- a/src/hostnet/lib/slirp.ml
+++ b/src/hostnet/lib/slirp.ml
@@ -41,7 +41,7 @@ let print_pcap = function
 type config = {
   peer_ip: Ipaddr.V4.t;
   local_ip: Ipaddr.V4.t;
-  extra_dns_ip: Ipaddr.V4.t;
+  extra_dns_ip: Ipaddr.V4.t list;
   pcap_settings: pcap Active_config.values;
 }
 
@@ -62,9 +62,8 @@ let connect x peer_ip local_ip extra_dns_ip =
         begin Tcpip_stack.connect ~config x
         >>= function
         | `Error (`Msg m) -> failwith m
-        | `Ok (s, (dns_ip, dns_udp)) ->
-          let (ip, udp) = Tcpip_stack.ipv4 s, Tcpip_stack.udpv4 s in
-            Tcpip_stack.listen_udpv4 s ~port:53 (Dns_forwarder.input ~secondary:false ~ip ~udp);
+        | `Ok (s, udps) ->
+            let ips_to_udp = List.combine extra_dns_ip udps in
             Vmnet.add_listener x (
               fun buf ->
                 match (Wire_structs.parse_ethernet_frame buf) with
@@ -130,15 +129,23 @@ let connect x peer_ip local_ip extra_dns_ip =
                         Tcpip_stack.IPV4.writev (Tcpip_stack.ipv4 s) ethernet_ip_hdr [ reply ];
                       end else begin
                         let payload = Cstruct.sub udp Wire_structs.sizeof_udp (length - Wire_structs.sizeof_udp) in
-                        let for_us = Ipaddr.V4.compare dst local_ip = 0 in
-                        let for_extra_dns = Ipaddr.V4.compare dst extra_dns_ip = 0 in
-                        if for_extra_dns && dst_port = 53 then begin
-                          Dns_forwarder.input ~secondary:true ~ip:dns_ip ~udp:dns_udp ~src ~dst ~src_port payload
-                        end
-                        (* We handle DNS on port 53 ourselves, see [listen_udpv4] above *)
-                        (* ... but if it's going to an external IP then we treat it like all other
-                           UDP and NAT it *)
-                        else if (not for_us) then begin
+                        let for_primary_ip = Ipaddr.V4.compare dst local_ip = 0 in
+                        let for_extra_dns = List.fold_left (||) false (List.map (fun ip -> Ipaddr.V4.compare dst ip = 0) extra_dns_ip) in
+                        let for_us = for_primary_ip || for_extra_dns in
+                        (* DNS to our primary IP *)
+                        if for_primary_ip && dst_port = 53 then begin
+                          let udp = Tcpip_stack.udpv4 s in
+                          Dns_forwarder.input ~secondary:false ~udp ~src ~dst ~src_port payload
+                        end else if for_extra_dns && dst_port = 53 then begin
+                          (* DNS to one of our secondary IPs *)
+                          Lwt_list.iter_s
+                            (fun (ip, udp) ->
+                              if Ipaddr.V4.compare dst ip = 0 && dst_port = 53 then begin
+                                Dns_forwarder.input ~secondary:true ~udp ~src ~dst ~src_port payload
+                              end else Lwt.return_unit
+                            ) ips_to_udp;
+                        end else if (not for_us) then begin
+                          (* For any other IP, NAT as usual *)
                           Log.debug (fun f -> f "UDP %s:%d -> %s:%d len %d"
                                        (Ipaddr.V4.to_string src) src_port
                                        (Ipaddr.V4.to_string dst) dst_port
@@ -164,7 +171,7 @@ let connect x peer_ip local_ip extra_dns_ip =
             Tcpip_stack.listen_tcpv4_flow s ~on_flow_arrival:(
               fun ~src:(src_ip, src_port) ~dst:(dst_ip, dst_port) ->
                 let for_us src_ip = Ipaddr.V4.compare src_ip local_ip = 0 in
-                let for_extra_dns = Ipaddr.V4.compare src_ip extra_dns_ip = 0 in
+                let for_extra_dns = List.fold_left (||) false (List.map (fun ip -> Ipaddr.V4.compare src_ip ip = 0) extra_dns_ip) in
                 let for_dns src_ip = for_us src_ip || for_extra_dns in
                 ( if for_dns src_ip && src_port = 53 then begin
                     Resolv_conf.get ()
@@ -297,9 +304,23 @@ let connect x peer_ip local_ip extra_dns_ip =
         Log.err (fun f -> f "Failed to parse IPv4 address '%s', using default of %s" x (Ipaddr.V4.to_string default));
         Lwt.return default
       | Some x -> Lwt.return x in
+    let parse_ipv4_list default x =
+      let all = List.map (fun x -> Ipaddr.V4.of_string @@ String.trim x) @@ Astring.String.cuts ~sep:"," x in
+      let any_none, some = List.fold_left (fun (any_none, some) x -> match x with
+        | None -> true, some
+        | Some x -> any_none, x :: some
+      ) (false, []) all in
+      if any_none then begin
+        Log.err (fun f -> f "Failed to parse IPv4 address list '%s', using default of %s" x (String.concat "," (List.map Ipaddr.V4.to_string default)));
+        Lwt.return default
+      end else Lwt.return some in
+
     let default_peer = "192.168.65.2" in
     let default_host = "192.168.65.1" in
-    let default_dns_extra = "192.168.65.3" in
+    let default_dns_extra = [
+      "192.168.65.3"; "192.168.65.4"; "192.168.65.5"; "192.168.65.6";
+      "192.168.65.7"; "192.168.65.8"; "192.168.65.9"; "192.168.65.10";
+    ] in
     Config.string config ~default:default_peer peer_ips_path
     >>= fun string_peer_ips ->
     Active_config.map (parse_ipv4 (Ipaddr.V4.of_string_exn default_peer)) string_peer_ips
@@ -314,11 +335,11 @@ let connect x peer_ip local_ip extra_dns_ip =
     Lwt.async (fun () -> restart_on_change "slirp/host" Ipaddr.V4.to_string host_ips);
 
     let extra_dns_ips_path = driver @ [ "slirp"; "extra_dns" ] in
-    Config.string config ~default:default_dns_extra extra_dns_ips_path
+    Config.string config ~default:(String.concat "," default_dns_extra) extra_dns_ips_path
     >>= fun string_extra_dns_ips ->
-    Active_config.map (parse_ipv4 (Ipaddr.V4.of_string_exn default_dns_extra)) string_extra_dns_ips
+    Active_config.map (parse_ipv4_list (List.map Ipaddr.V4.of_string_exn default_dns_extra)) string_extra_dns_ips
     >>= fun extra_dns_ips ->
-    Lwt.async (fun () -> restart_on_change "slirp/extra_dns" Ipaddr.V4.to_string extra_dns_ips);
+    Lwt.async (fun () -> restart_on_change "slirp/extra_dns" (fun x -> String.concat "," (List.map Ipaddr.V4.to_string x)) extra_dns_ips);
 
     let peer_ip = Active_config.hd peer_ips in
     let local_ip = Active_config.hd host_ips in

--- a/src/hostnet/lib/slirp.ml
+++ b/src/hostnet/lib/slirp.ml
@@ -176,7 +176,10 @@ let connect x peer_ip local_ip extra_dns_ip =
                 ( if for_dns src_ip && src_port = 53 then begin
                     Resolv_conf.get ()
                     >>= fun all ->
-                    match Dns_forward.choose_server ~secondary:for_extra_dns all with
+                    let nth, _ = List.fold_left (fun (nth, i) x ->
+                      (if Ipaddr.V4.compare src_ip x = 0 then i else nth), i + 1
+                    ) (0, 0) (local_ip :: extra_dns_ip) in
+                    match Dns_forward.choose_server ~nth all with
                     | Some (description, (Ipaddr.V4 ip, port)) ->
                       Lwt.return (":" ^ description, ip, port)
                     | _ ->

--- a/src/hostnet/lib/slirp.mli
+++ b/src/hostnet/lib/slirp.mli
@@ -7,7 +7,7 @@ type pcap = (string * int64 option) option
 type config = {
   peer_ip: Ipaddr.V4.t;
   local_ip: Ipaddr.V4.t;
-  extra_dns_ip: Ipaddr.V4.t;
+  extra_dns_ip: Ipaddr.V4.t list;
   pcap_settings: pcap Active_config.values;
 }
 (** A slirp TCP/IP stack ready to accept connections *)

--- a/src/hostnet/lib/tcpip_stack.mli
+++ b/src/hostnet/lib/tcpip_stack.mli
@@ -4,9 +4,9 @@ include Sig.TCPIP
 type configuration
 
 val make: client_macaddr:Macaddr.t -> server_macaddr:Macaddr.t
-  -> peer_ip: Ipaddr.V4.t -> local_ip:Ipaddr.V4.t -> extra_dns_ip:Ipaddr.V4.t -> configuration
+  -> peer_ip: Ipaddr.V4.t -> local_ip:Ipaddr.V4.t -> extra_dns_ip:Ipaddr.V4.t list -> configuration
 
 val connect:
   config:configuration -> Vmnet.t
-  -> [ `Ok of t * (ipv4 * udpv4) | `Error of [ `Msg of string ] ] Lwt.t
+  -> [ `Ok of (t * udpv4 list) | `Error of [ `Msg of string ] ] Lwt.t
 end

--- a/src/hostnet/lib_test/main.ml
+++ b/src/hostnet/lib_test/main.ml
@@ -65,7 +65,7 @@ let config =
   {
     Slirp.peer_ip = Ipaddr.V4.of_string_exn "192.168.65.2";
     local_ip = Ipaddr.V4.of_string_exn "192.168.65.1";
-    extra_dns_ip = Ipaddr.V4.of_string_exn "192.168.65.3";
+    extra_dns_ip = [ Ipaddr.V4.of_string_exn "192.168.65.3" ];
     pcap_settings = Active_config.Value(None, never);
   }
 

--- a/src/hostnet/lib_test/main.ml
+++ b/src/hostnet/lib_test/main.ml
@@ -9,7 +9,10 @@ let src =
 module Log = (val Logs.src_log src : Logs.LOG)
 
 module Resolv_conf = struct
-  let get () = Lwt.return [ Ipaddr.V4 (Ipaddr.V4.of_string_exn "8.8.8.8"), 53 ]
+  let get () = Lwt.return [
+    Ipaddr.V4 (Ipaddr.V4.of_string_exn "8.8.8.8"), 53;
+    Ipaddr.V4 (Ipaddr.V4.of_string_exn "8.8.4.4"), 53;
+  ]
   let set _ = ()
   let set_default_dns _ = ()
 end

--- a/src/hostnet/opam
+++ b/src/hostnet/opam
@@ -32,6 +32,7 @@ depends: [
   "charrua-core" { >= "0.3" }
   "logs"
   "fmt"
+  "astring"
   "mirage-flow" { >= "1.1.0" }
   "mirage-types-lwt" { = "999" }
   "ounit"


### PR DESCRIPTION
This PR generalises the mechanism to include a list of server IPs rather than a single primary and single secondary.

The PR also adds another 8 virtual DNS IPs. Hopefully this will work better for people who have more than 2 real DNS servers -- this probably happens when connecting to a VPN, where you are likely to gain additional servers.

Fixes #99