### PR TITLE
Extend the connection limit

### DIFF
--- a/opam/darwin/packages/dev/tcpip.999/url
+++ b/opam/darwin/packages/dev/tcpip.999/url
@@ -1,1 +1,1 @@
-git: "git://github.com/djs55/mirage-tcpip#3.0.0-beta7"
+git: "git://github.com/djs55/mirage-tcpip#3.0.0-beta8"

--- a/src/com.docker.slirp/src/bind.ml
+++ b/src/com.docker.slirp/src/bind.ml
@@ -22,6 +22,11 @@ module Make(Socket: Sig.SOCKETS) = struct
     c: Channel.t;
   }
 
+  let register_connection = Socket.register_connection
+  let deregister_connection = Socket.deregister_connection
+  let set_max_connections = Socket.set_max_connections
+  let dump_connection_table = Socket.dump_connection_table
+
   module Infix = struct
     let ( >>= ) m f = m >>= function
       | `Ok x -> f x
@@ -56,25 +61,31 @@ module Make(Socket: Sig.SOCKETS) = struct
     let rawfd = Socket.Stream.Unix.unsafe_get_raw_fd t.fd in
     let result = String.make 8 '\000' in
     let n, _, fd = Fd_send_recv.recv_fd rawfd result 0 8 [] in
-    if n <> 8 then Lwt.return (`Error (`Msg (Printf.sprintf "Message only contained %d bytes" n))) else begin
-      let buf = Cstruct.create 8 in
-      Cstruct.blit_from_string result 0 buf 0 8;
-      Log.debug (fun f ->
-          let b = Buffer.create 16 in
-          Cstruct.hexdump_to_buffer b buf;
-          f "received result bytes: %s which is %s" (String.escaped result) (Buffer.contents b)
-        );
-      match Cstruct.LE.get_uint64 buf 0 with
-      | 0L -> Lwt.return (`Ok fd)
-      | n ->
-        Unix.close fd;
-        begin match n with
-          | 48L -> Lwt.return (`Error (`Msg "EADDRINUSE"))
-          | 49L -> Lwt.return (`Error (`Msg "EADDRNOTAVAIL"))
-          | n   ->
-            Lwt.return (`Error (`Msg ("Failed to bind: unrecognised errno: " ^ (Int64.to_string n))))
-        end
-    end
+
+    ( if n <> 8 then Lwt.return (`Error (`Msg (Printf.sprintf "Message only contained %d bytes" n))) else begin
+        let buf = Cstruct.create 8 in
+        Cstruct.blit_from_string result 0 buf 0 8;
+        Log.debug (fun f ->
+            let b = Buffer.create 16 in
+            Cstruct.hexdump_to_buffer b buf;
+            f "received result bytes: %s which is %s" (String.escaped result) (Buffer.contents b)
+          );
+        match Cstruct.LE.get_uint64 buf 0 with
+        | 0L -> Lwt.return (`Ok fd)
+        | n ->
+          begin match n with
+            | 48L -> Lwt.return (`Error (`Msg "EADDRINUSE"))
+            | 49L -> Lwt.return (`Error (`Msg "EADDRNOTAVAIL"))
+            | n   ->
+              Lwt.return (`Error (`Msg ("Failed to bind: unrecognised errno: " ^ (Int64.to_string n))))
+          end
+      end )
+    >>= function
+    | `Error x ->
+      Unix.close fd;
+      Lwt.return (`Error x)
+    | `Ok x ->
+      Lwt.return (`Ok x)
 
   (* This implementation is OSX-only *)
   let request_privileged_port local_ip local_port sock_stream =

--- a/src/com.docker.slirp/src/connect.mli
+++ b/src/com.docker.slirp/src/connect.mli
@@ -3,8 +3,6 @@ open Hostnet
 module Make_unix(Host: Sig.HOST): sig
   include Sig.Connector
 
-  val set_max_connections: int option -> unit
-
   val vsock_path: string ref
 end
 
@@ -12,6 +10,4 @@ module Make_hvsock(Host: Sig.HOST): sig
   include Sig.Connector
 
   val set_port_forward_addr: Hvsock.sockaddr -> unit
-
-  val set_max_connections: int option -> unit
 end

--- a/src/hostnet/lib/sig.ml
+++ b/src/hostnet/lib/sig.ml
@@ -74,6 +74,15 @@ end
 module type SOCKETS = sig
   (* An OS-based BSD sockets implementation *)
 
+  val set_max_connections: int option -> unit
+  (** Set the maximum number of connections we permit ourselves to use. This
+      is to prevent starving global OS resources, particularly on OSX *)
+
+  (** TODO: hide these by refactoring Hyper-V sockets stuff *)
+  val register_connection: string -> int Lwt.t
+  val deregister_connection: int -> unit
+  val dump_connection_table: unit -> unit
+  
   module Datagram: sig
 
     type address = Ipaddr.t * int

--- a/src/hostnet/lib_test/main.ml
+++ b/src/hostnet/lib_test/main.ml
@@ -324,4 +324,10 @@ let tests =
 (* Run it *)
 let () =
   Logs.set_reporter (Logs_fmt.reporter ());
+  Lwt.async_exception_hook := (fun exn ->
+    Log.err (fun f -> f "Lwt.async failure %s: %s"
+      (Printexc.to_string exn)
+      (Printexc.get_backtrace ())
+    )
+  );
   Alcotest.run "Hostnet" tests


### PR DESCRIPTION
Previously we would cap the total number of connections we would `accept` and forward into the VM-- this still allowed us to hit system limits by forwarding regular connections out of the VM (particularly on OSX). This PR extends the connection limiting code to all connections, irrespective of direction.