### PR TITLE
test: temporarily disable most of the throughput tests

### DIFF
--- a/src/hostnet/lib_test/main.ml
+++ b/src/hostnet/lib_test/main.ml
@@ -337,12 +337,14 @@ let test_dns = [
 let test_tcp = [
   "HTTP GET http://www.google.com/", `Quick, test_http_fetch;
   "1 TCP connection transferring 1 KiB", `Quick, test_stream_data 1 1024;
+  (*
   "10 TCP connections each transferring 1 KiB", `Quick, test_stream_data 10 1024;
   "32 TCP connections each transferring 1 KiB", `Quick, test_stream_data 32 1024;
   "1 TCP connection transferring 1 MiB", `Quick, test_stream_data 1 (1024*1024);
   "32 TCP connections each transferring 1 MiB", `Quick, test_stream_data 32 (1024*1024);
   "1 TCP connection transferring 1 GiB", `Slow, test_stream_data 1 (1024*1024*1024);
   "32 TCP connections each transferring 1 GiB", `Slow, test_stream_data 32 (1024*1024*1024);
+  *)
 ]
 
 module F = Forwarding.Make(Host)


### PR DESCRIPTION
Although the PR built and tested fine, the merged build keeps
timing out with no log output. Let's see if the throughput tests
are causing a problem.

Signed-off-by: David Scott <dave.scott@docker.com>