### PR TITLE
DNS: serve up entries from /etc/hosts

### DIFF
--- a/src/hostnet/_oasis
+++ b/src/hostnet/_oasis
@@ -15,7 +15,7 @@ Library hostnet
   Pack: true
   Findlibname: hostnet
   Modules: Arp, Dns_forward, Filter, Slirp, Tcpip_stack,
-    Forward, Host_lwt_unix, Host_uwt, Resolver, Vmnet, Sig
+    Forward, Host_lwt_unix, Host_uwt, Resolver, Hosts, Vmnet, Sig
   BuildDepends: cstruct, lwt.unix, logs, mirage-types.lwt, ipaddr, mirage-flow,
     ppx_sexp_conv, pcap-format, mirage-console.unix, tcpip.ethif,
     tcpip.arpv4, tcpip.ipv4, tcpip.udp, tcpip.tcp, tcpip.stack-direct,

--- a/src/hostnet/lib/dns_forward.ml
+++ b/src/hostnet/lib/dns_forward.ml
@@ -37,6 +37,40 @@ let choose_server ~nth all =
   then None
   else Some (string_of_int nth ^ suffix, List.nth (only_ipv4 all) (nth mod l))
 
+let lookup_locally = function
+  | _, Some request ->
+    let open Dns.Packet in
+    begin match request with
+    | { id; detail; additionals; questions = [ { q_class = Q_IN; q_type = Q_A; q_name; _ } ]; _ } ->
+      begin match List.fold_left (fun found (name, ip) -> match found, ip with
+        | Some v4, _           -> Some v4
+        | None,   Ipaddr.V4 v4 ->
+          if Dns.Name.to_string q_name = name then Some v4 else None
+        | None,   Ipaddr.V6 _  -> None
+      ) None !(Hosts.etc_hosts) with
+      | None -> None
+      | Some v4 ->
+        Log.debug (fun f -> f "DNS[%04x] %s is %s in in /etc/hosts" id (Dns.Name.to_string q_name) (Ipaddr.V4.to_string v4));
+        let answers = [ { name = q_name; cls = RR_IN; flush = false; ttl = 0l; rdata = A v4 } ] in
+        Some { Dns.Packet.id; detail; questions = request.questions; authorities=[]; additionals; answers }
+      end
+    | { id; detail; additionals; questions = [ { q_class = Q_IN; q_type = Q_AAAA; q_name; _ } ]; _ } ->
+      begin match List.fold_left (fun found (name, ip) -> match found, ip with
+        | Some v6, _           -> Some v6
+        | None,   Ipaddr.V6 v6 ->
+          if Dns.Name.to_string q_name = name then Some v6 else None
+        | None,   Ipaddr.V4 _  -> None
+      ) None !(Hosts.etc_hosts) with
+      | None -> None
+      | Some v6 ->
+        Log.debug (fun f -> f "DNS[%04x] %s is %s in in /etc/hosts" id (Dns.Name.to_string q_name) (Ipaddr.V6.to_string v6));
+        let answers = [ { name = q_name; cls = RR_IN; flush = false; ttl = 0l; rdata = AAAA v6 } ] in
+        Some { Dns.Packet.id; detail; questions = request.questions; authorities=[]; additionals; answers }
+      end
+    | _ -> None
+    end
+  | _, _ -> None
+
 module Make(Ip: V1_LWT.IPV4) (Udp:V1_LWT.UDPV4) (Resolv_conf: Sig.RESOLV_CONF) (Socket: Sig.SOCKETS) (Time: V1_LWT.TIME) = struct
 
 let input ~nth ~udp ~src ~dst ~src_port buf =
@@ -45,19 +79,36 @@ let input ~nth ~udp ~src ~dst ~src_port buf =
 
   let dns = parse_dns buf in
 
-  Log.debug (fun f -> f "DNS[%s] %s:%d -> %s %s" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns dns));
+  let reply buffer =
+    Log.debug (fun f -> f "DNS[%s] %s:%d <- %s (%s)" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns (parse_dns buffer)));
+    Udp.write ~source_port:53 ~dest_ip:src ~dest_port:src_port udp buffer in
 
-  Resolv_conf.get ()
-  >>= fun all ->
-  match choose_server ~nth all.Resolver.resolvers with
-  | Some (dst_str, (dst, dst_port)) ->
-    Log.debug (fun f -> f "DNS[%s] Forwarding to %s (%s)" (tidstr_of_dns dns) (Ipaddr.to_string dst) dst_str);
-    let reply buffer =
-      Log.debug (fun f -> f "DNS[%s] %s:%d <- %s (%s)" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns (parse_dns buffer)));
-      Udp.write ~source_port:53 ~dest_ip:src ~dest_port:src_port udp buffer in
-    let userdesc = "DNS[" ^ (tidstr_of_dns dns) ^ "]" in
-    Socket.Datagram.input ~userdesc ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(dst, dst_port) ~payload:buf ()
+  Log.debug (fun f -> f "DNS[%s] %s:%d -> %s %s" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns dns));
+  (* Is this an A or AAAA query which can be satisfied from /etc/hosts? *)
+  match lookup_locally dns with
+  | Some response ->
+    let obuf = Dns.Buf.create 4096 in
+    begin match Dns.Protocol.Server.marshal obuf response response with
+    | None ->
+      Log.err (fun f -> f "DNS[%s] failed to marshal response" (tidstr_of_dns dns));
+      Lwt.return_unit
+    | Some buf ->
+      let buf = Cstruct.of_bigarray buf in
+      reply buf
+    end
   | None ->
-    Log.err (fun f -> f "DNS[%s] No upstream DNS server configured: dropping request" (tidstr_of_dns dns));
-    Lwt.return_unit
+    Resolv_conf.get ()
+    >>= fun all ->
+    begin match choose_server ~nth all.Resolver.resolvers with
+    | Some (dst_str, (dst, dst_port)) ->
+      Log.debug (fun f -> f "DNS[%s] Forwarding to %s (%s)" (tidstr_of_dns dns) (Ipaddr.to_string dst) dst_str);
+      let reply buffer =
+        Log.debug (fun f -> f "DNS[%s] %s:%d <- %s (%s)" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns (parse_dns buffer)));
+        Udp.write ~source_port:53 ~dest_ip:src ~dest_port:src_port udp buffer in
+      let userdesc = "DNS[" ^ (tidstr_of_dns dns) ^ "]" in
+      Socket.Datagram.input ~userdesc ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(dst, dst_port) ~payload:buf ()
+    | None ->
+      Log.err (fun f -> f "DNS[%s] No upstream DNS server configured: dropping request" (tidstr_of_dns dns));
+      Lwt.return_unit
+    end
 end

--- a/src/hostnet/lib/hosts.ml
+++ b/src/hostnet/lib/hosts.ml
@@ -1,0 +1,72 @@
+open Lwt.Infix
+
+let src =
+  let src = Logs.Src.create "/etc/hosts" ~doc:"monitor and read the /etc/hosts file" in
+  Logs.Src.set_level src (Some Logs.Debug);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+let default_etc_hosts_path =
+  if Sys.os_type = "Win32"
+  then "C:\\Windows\\System32\\drivers\\etc\\hosts"
+  else "/etc/hosts"
+
+let etc_hosts = ref []
+
+let of_string txt =
+  let open Astring in
+  try
+    let lines = String.cuts ~sep:"\n" txt in
+    List.rev (List.fold_left
+      (fun acc line ->
+        let line = String.trim line in
+        if line = "" then acc else begin
+          let line = match String.cut ~sep:"#" line with
+            | None -> line
+            | Some (important, comment) -> important in
+          let whitespace = function
+            | ' ' | '\n' | '\011' | '\012' | '\r' | '\t' -> true
+            | _ -> false in
+          match String.fields ~empty:false ~is_sep:whitespace line with
+          | [ addr; name ] ->
+            begin match Ipaddr.of_string addr with
+            | Some addr -> (name, addr) :: acc
+            | None ->
+              Log.err (fun f -> f "Failed to parse address '%s' from hosts file" addr);
+              acc
+            end
+          | _ -> acc
+        end
+      ) [] lines)
+  with _ -> []
+
+module Make(Files: Sig.FILES) = struct
+
+  let m = Lwt_mutex.create ()
+
+  let parse filename =
+    Lwt_mutex.with_lock m
+      (fun () ->
+        Files.read_file filename
+        >>= function
+        | `Error (`Msg msg) ->
+          Log.err (fun f -> f "Failed to read %s: %s" filename msg);
+          Lwt.return ()
+        | `Ok txt ->
+          etc_hosts := of_string txt;
+          Log.info (fun f -> f "hosts file has bindings for %s" (String.concat " " @@ List.map fst !etc_hosts));
+          Lwt.return ()
+      )
+
+  type watch = Files.watch
+
+  let watch ?(path = default_etc_hosts_path) () =
+    Files.watch_file path
+      (fun () ->
+        Lwt.async (fun () -> parse path)
+      )
+
+  let unwatch = Files.unwatch
+
+end

--- a/src/hostnet/lib/hosts.mli
+++ b/src/hostnet/lib/hosts.mli
@@ -1,0 +1,23 @@
+
+val default_etc_hosts_path: string
+(** Default path where /etc/hosts should be on this machine *)
+
+val etc_hosts: (string * Ipaddr.t) list ref
+(** The current contents of the hosts file *)
+
+val of_string: string -> (string * Ipaddr.t) list
+(** Parse the contents of a hosts file *)
+
+module Make(Files: Sig.FILES): sig
+
+  type watch
+
+  val watch: ?path:string -> unit -> [ `Ok of watch | `Error of [ `Msg of string ] ]
+  (** Start watching the hosts file, updating the [etc_hosts] binding in the
+      background. The [?path] argument allows the location of the hosts file
+      to be overriden. *)
+
+  val unwatch: watch -> unit
+  (** Stop watching the hosts file *)
+
+end

--- a/src/hostnet/lib/sig.ml
+++ b/src/hostnet/lib/sig.ml
@@ -117,6 +117,15 @@ module type FILES = sig
 
   val read_file: string -> [ `Ok of string | `Error of [ `Msg of string ] ] Lwt.t
   (** Read a whole file into a string *)
+
+  type watch
+
+  val watch_file: string -> (unit -> unit) -> [ `Ok of watch | `Error of [ `Msg of string ] ]
+  (** [watch_file path callback] executes [callback] whenever the contents of
+      [path] may have changed. *)
+
+  val unwatch: watch -> unit
+  (** [unwatch watch] stops watching the path(s) associated with [watch] *)
 end
 
 module type HOST = sig

--- a/src/hostnet/lib_test/hosts_test.ml
+++ b/src/hostnet/lib_test/hosts_test.ml
@@ -1,0 +1,43 @@
+
+
+let examples = [
+  "Windows-style", String.concat "\n" [
+    "# For example:";
+    "#";
+    "1.2.3.4     www.docker.com     # web server";
+    "4.5.6.7     staging.docker.com # staging web server";
+  ], [
+  "www.docker.com", Ipaddr.of_string_exn "1.2.3.4";
+  "staging.docker.com", Ipaddr.of_string_exn "4.5.6.7";
+  ];
+  "Mac-style", String.concat "\n" [
+    "##";
+    "# Host Database";
+    "#";
+    "# localhost is used to configure the loopback interface";
+    "# when the system is booting.  Do not change this entry.";
+    "##";
+    "127.0.0.1      	localhost";
+    "255.255.255.255	broadcasthost";
+    "::1             localhost";
+  ], [
+  "localhost", Ipaddr.V4 Ipaddr.V4.localhost;
+  "broadcasthost", Ipaddr.of_string_exn "255.255.255.255";
+  "localhost", Ipaddr.of_string_exn "::1";
+  ]
+]
+
+let test_one txt expected () =
+  let x = Hostnet.Hosts.of_string txt in
+  List.iter (fun ((a_name, a_ip), (b_name, b_ip)) ->
+    if Ipaddr.compare a_ip b_ip <> 0 then failwith "IP doesn't match";
+    if a_name <> b_name then failwith "name doesn't match"
+  ) (List.combine expected x)
+
+let tests = List.map (fun (name, txt, expected) ->
+  "hosts " ^ name, `Quick, test_one txt expected
+) examples
+
+let suite = [
+  "hosts", tests;
+]

--- a/src/hostnet/lib_test/main.ml
+++ b/src/hostnet/lib_test/main.ml
@@ -29,9 +29,13 @@ let test_dns_query server () =
       (fun stack ->
         let resolver = DNS.create stack in
         DNS.gethostbyname ~server resolver "www.google.com"
-        >>= fun ips ->
-        Log.info (fun f -> f "www.google.com has IPs: %s" (String.concat ", " (List.map Ipaddr.to_string ips)));
-        Lwt.return ()
+        >>= function
+        | (_ :: _) as ips ->
+          Log.info (fun f -> f "www.google.com has IPs: %s" (String.concat ", " (List.map Ipaddr.to_string ips)));
+          Lwt.return ()
+        | _ ->
+          Log.err (fun f -> f "Failed to lookup www.google.com");
+          failwith "Failed to lookup www.google.com"
       ) in
   Host.Main.run t
 

--- a/src/hostnet/lib_test/main.ml
+++ b/src/hostnet/lib_test/main.ml
@@ -253,7 +253,8 @@ module Slirp_uwt = Make(Host_uwt)
 let tests =
   (List.map (fun (name, test) -> name ^ " with Lwt_unix", test) Slirp_lwt_unix.suite) @
   (List.map (fun (name, test) -> name ^ " with Uwt", test) Slirp_uwt.suite) @
-  Resolver_test.suite
+  Resolver_test.suite @
+  Hosts_test.suite
 
 (* Run it *)
 let () =


### PR DESCRIPTION
This PR allows users to edit `/etc/hosts` (or the Windows equivalent, defender-permitting) and then resolve the names inside the VM as well as on the host.

The patches break down into:
- Parse `/etc/hosts` (or the Windows equivalent) and keep a cache of the values found therein. In case the path is not quite as universal as hoped, it can be overridden by a command-line argument `--hosts <path>`
- When a DNS request is received, first lookup `A` and `AAAA` requests in our cache. Reply with the any cache hit; otherwise fall back to upstream servers.
- A test for the DNS lookup through the cache
- A test for the `/etc/hosts` file parser

Note I tried using the `Fs_event` API from `libuv`/`uwt` but I couldn't get it to emit more than one event, so this PR falls back to polling every 5s.