### PR TITLE
Reduce log spam

### DIFF
--- a/opam/darwin/packages/dev/tcpip.999/url
+++ b/opam/darwin/packages/dev/tcpip.999/url
@@ -1,1 +1,1 @@
-git: "git://github.com/djs55/mirage-tcpip#3.0.0-beta5"
+git: "git://github.com/djs55/mirage-tcpip#3.0.0-beta6"

--- a/src/hostnet/lib/arp.ml
+++ b/src/hostnet/lib/arp.ml
@@ -26,7 +26,7 @@
 
 let src =
   let src = Logs.Src.create "arp" ~doc:"fixed ARP table" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)


### PR DESCRIPTION
Since the reducing of the DHCP lease time, the amount of log spam has increased. This PR tries to silence some of the worst offenders:
- remove a `printf` in mirage-tcpip (current upstream uses different logging now which we'll inherit when we move to it)
- stop printing arp debug messages by default (the arp implementation seems pretty solid)
- avoid double-processing the `BOOTREQUEST` messages

The latter is quite interesting: we currently hook the DHCP client in via a `Netif` listener, which allows it to send and receive raw frames. Indeed, the DHCP packet parsing function expects to see the whole ethernet frame. Unfortunately the TCPIP stack also receives the frame and complains that no-one is listening on port 67. When we migrate away from using the TCPIP stack, towards a more low-level driver of the TCP code we will be able to avoid double-processing these packets. 
