### PR TITLE
Revert "dhcp: set the lease time to 10s"

### DIFF
--- a/src/hostnet/lib/tcpip_stack.ml
+++ b/src/hostnet/lib/tcpip_stack.ml
@@ -74,8 +74,8 @@ let make ~client_macaddr ~server_macaddr ~peer_ip ~local_ip ~extra_dns_ip ~get_d
       options = options;
       hostname = "vpnkit"; (* it's us! *)
       hosts = [ hyperkit ];
-      default_lease_time = Int32.of_int 10; (* 10s *)
-      max_lease_time = Int32.of_int 10; (* 10s *)
+      default_lease_time = Int32.of_int (60 * 60 * 2); (* 2 hours, from charrua defaults *)
+      max_lease_time = Int32.of_int (60 * 60 * 24) ; (* 24 hours, from charrua defaults *)
       ip_addr = local_ip;
       mac_addr = server_macaddr;
       network = prefix;


### PR DESCRIPTION
This reverts commit 6ea1b3809586748f0322651fa7704e7372d87256.

Unfortunately the short lease time has exposed a problem with the
mirage-tcpip stack, which we need to fix before we can do this.

Signed-off-by: David Scott <dave.scott@docker.com>