### PR TITLE
Increase UDP datagram limits

### DIFF
--- a/src/hostnet/_oasis
+++ b/src/hostnet/_oasis
@@ -14,7 +14,7 @@ Library hostnet
   Path: lib
   Pack: true
   Findlibname: hostnet
-  Modules: Arp, Dns_forward, Filter, Slirp, Tcpip_stack,
+  Modules: Constants, Arp, Dns_forward, Filter, Slirp, Tcpip_stack,
     Forward, Host_lwt_unix, Host_uwt, Resolver, Hosts, Vmnet, Sig
   BuildDepends: cstruct, lwt.unix, logs, mirage-types.lwt, ipaddr, mirage-flow,
     ppx_sexp_conv, pcap-format, mirage-console.unix, tcpip.ethif,

--- a/src/hostnet/lib/constants.ml
+++ b/src/hostnet/lib/constants.ml
@@ -1,0 +1,1 @@
+let max_udp_length = 65507 (* IP datagram (65535) - IP header(20) - UDP header(8) *)

--- a/src/hostnet/lib/forward.ml
+++ b/src/hostnet/lib/forward.ml
@@ -162,8 +162,6 @@ let start_tcp_proxy description vsock_path_var remote_port server =
     );
   Lwt.return ()
 
-let max_udp_length = 2048 (* > 1500 the MTU of our link + header *)
-
 let max_vsock_header_length = 1024
 
 let conn_read flow buf =
@@ -184,9 +182,9 @@ let conn_write flow buf =
 
 let start_udp_proxy description vsock_path_var remote_port server =
   let open Lwt.Infix in
-  let from_internet_buffer = Cstruct.create max_udp_length in
+  let from_internet_buffer = Cstruct.create Constants.max_udp_length in
   (* We write to the internet using the from_vsock_buffer *)
-  let from_vsock_buffer = Cstruct.create max_udp_length in
+  let from_vsock_buffer = Cstruct.create Constants.max_udp_length in
   let handle fd =
     Active_list.Var.read vsock_path_var
     >>= fun _vsock_path ->

--- a/src/hostnet/lib/host_lwt_unix.ml
+++ b/src/hostnet/lib/host_lwt_unix.ml
@@ -128,8 +128,8 @@ module Datagram = struct
          let flow = { description; fd; last_use; reply} in
          Hashtbl.replace table (src, src_port) flow;
          (* Start a listener *)
-         let buffer = Cstruct.create 1500 in
-         let bytes = Bytes.make 1500 '\000' in
+         let buffer = Cstruct.create Constants.max_udp_length in
+         let bytes = Bytes.make Constants.max_udp_length '\000' in
          let rec loop () =
            Lwt.catch
              (fun () ->

--- a/src/hostnet/lib/host_uwt.ml
+++ b/src/hostnet/lib/host_uwt.ml
@@ -204,12 +204,12 @@ module Sockets = struct
         end;
         Lwt.return_unit
 
-      let recvfrom server buf =
+      let rec recvfrom server buf =
         Uwt.Udp.recv_ba ~pos:buf.Cstruct.off ~len:buf.Cstruct.len ~buf:buf.Cstruct.buffer server.fd
         >>= fun recv ->
         if recv.Uwt.Udp.is_partial then begin
-          Log.err (fun f -> f "Socket.Datagram.recvfrom: dropping partial response");
-          Lwt.fail (Failure "Socket.Datagram.recvfrom partial response")
+          Log.err (fun f -> f "Socket.Datagram.recvfrom: dropping partial response (buffer was %d bytes)" (Cstruct.len buf));
+          recvfrom server buf
         end else match recv.Uwt.Udp.sockaddr with
           | None ->
             Log.err (fun f -> f "Socket.Datagram.recvfrom: dropping response from unknown sockaddr");

--- a/src/hostnet/lib/host_uwt.ml
+++ b/src/hostnet/lib/host_uwt.ml
@@ -108,14 +108,14 @@ module Sockets = struct
              let flow = { description; fd; last_use; reply} in
              Hashtbl.replace table (src, src_port) flow;
              (* Start a listener *)
-             let buf = Cstruct.create 1500 in
+             let buf = Cstruct.create Constants.max_udp_length in
              let rec loop () =
                Lwt.catch
                  (fun () ->
                     Uwt.Udp.recv_ba ~pos:buf.Cstruct.off ~len:buf.Cstruct.len ~buf:buf.Cstruct.buffer fd
                     >>= fun recv ->
                     if recv.Uwt.Udp.is_partial then begin
-                      Log.err (fun f -> f "Socket.Datagram.input %s: dropping partial response" description);
+                      Log.err (fun f -> f "Socket.Datagram.input %s: dropping partial response (buffer was %d)" description (Cstruct.len buf));
                       Lwt.return true
                     end else if recv.Uwt.Udp.sockaddr = None then begin
                       Log.err (fun f -> f "Socket.Datagram.input %s: dropping response from unknown sockaddr" description);


### PR DESCRIPTION
The maximum UDPv4 datagram size is 65507 (which is IPv4 datagram (65535) - IPv4 header(20) - UDPv4 header(8)). Previously the code assumed the size was limited to the MTU of the ethernet network.

Furthermore, if we get a "partial" `recvfrom` (which means the packet was too big for the buffer) then log and continue. Previously we would shut down the listening thread which caused UDP forwarding to stop working.

Related to [docker/for-mac#674]