### PR TITLE
Attempt to fix watermarking

### DIFF
--- a/src/com.docker.slirp/Makefile
+++ b/src/com.docker.slirp/Makefile
@@ -4,7 +4,7 @@ build: src/depends.ml
 src/depends.ml: src/depends.ml.in
 	opam config subst src/depends.ml
 	cp src/depends.ml src/depends.tmp
-	sed -e 's/%%HOSTNET_PINNED%%/$(shell opam info hostnet -f pinned)/g' src/depends.tmp src/depends.ml
+	sed -e 's/%%VERSION%%/$(shell git rev-parse HEAD)/g' src/depends.tmp > src/depends.ml
 	cp src/depends.ml src/depends.tmp
 	sed -e 's/%%HOSTNET_PINNED%%/$(shell opam info hostnet -f pinned)/g' src/depends.tmp > src/depends.ml
 	cp src/depends.ml src/depends.tmp

--- a/src/com.docker.slirp/pkg/pkg.ml
+++ b/src/com.docker.slirp/pkg/pkg.ml
@@ -5,8 +5,6 @@
 open Topkg
 open Result
 
-let distrib = Pkg.distrib ~files_to_watermark:(fun () -> Ok [ "src/depends.ml" ]) ()
-
 let () =
-  Pkg.describe ~distrib ~change_logs:[] ~metas:[] "com.docker.slirp" @@ fun c ->
+  Pkg.describe ~change_logs:[] ~metas:[] "com.docker.slirp" @@ fun c ->
   Ok [ Pkg.bin "src/main" ~dst:"com.docker.slirp" ]


### PR DESCRIPTION
We substitute %%VERSION%% with the $(git rev-parse HEAD), and attempt
to substitute the %%*_PINNED%% properly.

Signed-off-by: David Scott <dave.scott@docker.com>