### PR TITLE
For DNS, make the UDP NAT rules one-shot

### DIFF
--- a/src/hostnet/lib/dns_forward.ml
+++ b/src/hostnet/lib/dns_forward.ml
@@ -106,7 +106,7 @@ let input ~nth ~udp ~src ~dst ~src_port buf =
         Log.debug (fun f -> f "DNS[%s] %s:%d <- %s (%s)" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns (parse_dns buffer)));
         Udp.write ~source_port:53 ~dest_ip:src ~dest_port:src_port udp buffer in
       let userdesc = "DNS[" ^ (tidstr_of_dns dns) ^ "]" in
-      Socket.Datagram.input ~userdesc ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(dst, dst_port) ~payload:buf ()
+      Socket.Datagram.input ~userdesc ~oneshot:true ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(dst, dst_port) ~payload:buf ()
     | None ->
       Log.err (fun f -> f "DNS[%s] No upstream DNS server configured: dropping request" (tidstr_of_dns dns));
       Lwt.return_unit

--- a/src/hostnet/lib/sig.ml
+++ b/src/hostnet/lib/sig.ml
@@ -46,7 +46,7 @@ module type DATAGRAM = sig
 
   type reply = Cstruct.t -> unit Lwt.t
 
-  val input: ?userdesc:string -> reply:reply -> src:address -> dst:address -> payload:Cstruct.t -> unit -> unit Lwt.t
+  val input: ?userdesc:string -> oneshot:bool -> reply:reply -> src:address -> dst:address -> payload:Cstruct.t -> unit -> unit Lwt.t
 
   val get_nat_table_size: unit -> int
   (** Return the current number of allocated NAT table entries *)

--- a/src/hostnet/lib/slirp.ml
+++ b/src/hostnet/lib/slirp.ml
@@ -150,7 +150,7 @@ let connect x peer_ip local_ip extra_dns_ip get_domain_search =
                                        length
                                    );
                           let reply buf = Tcpip_stack.UDPV4.writev ~source_ip:dst ~source_port:dst_port ~dest_ip:src ~dest_port:src_port (Tcpip_stack.udpv4 s) [ buf ] in
-                          Socket.Datagram.input ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(Ipaddr.V4 dst, dst_port) ~payload ()
+                          Socket.Datagram.input ~oneshot:false ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(Ipaddr.V4 dst, dst_port) ~payload ()
                         end
                         else if for_us && dst_port = 123 then begin
                           (* port 123 is special -- proxy these requests to
@@ -159,7 +159,7 @@ let connect x peer_ip local_ip extra_dns_ip get_domain_search =
                           let localhost = Ipaddr.V4.localhost in
                           Log.debug (fun f -> f "UDP/123 request from port %d -- sending it to %a:%d" src_port Ipaddr.V4.pp_hum localhost dst_port);
                           let reply buf = Tcpip_stack.UDPV4.writev ~source_ip:local_ip ~source_port:dst_port ~dest_ip:src ~dest_port:src_port (Tcpip_stack.udpv4 s) [ buf ] in
-                          Socket.Datagram.input ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(Ipaddr.V4 localhost, dst_port) ~payload ()
+                          Socket.Datagram.input ~oneshot:false ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(Ipaddr.V4 localhost, dst_port) ~payload ()
                         end else Lwt.return_unit
                       end
                     | _ -> Lwt.return_unit


### PR DESCRIPTION
Previously we would hold open a UDP NAT rule (and associated
socket) for 60s. This could waste a lot of sockets for DNS-heavy
workloads.

This patch closes the socket and removes the rule as soon as the
response is received. If the response is never received then the
GC will kick-in as before.

This is a short term patch before the next DNS rewrite.

Signed-off-by: David Scott <dave.scott@docker.com>