### PR TITLE
dhcp: remove the static map, allow exactly one dynamic IP

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "7.3"
+    version: "8.0"
   environment:
     OPAMYES: "1"
     OPAMJOBS: "2"

--- a/opam/darwin/packages/dev/charrua-core.999/url
+++ b/opam/darwin/packages/dev/charrua-core.999/url
@@ -1,1 +1,1 @@
-git: "https://github.com/djs55/charrua-core.git#fixed-lease-v0.3"
+git: "https://github.com/djs55/charrua-core.git#singleton-lease"

--- a/src/hostnet/lib/filter.ml
+++ b/src/hostnet/lib/filter.ml
@@ -19,26 +19,29 @@ module Make(Input: Sig.VMNET) = struct
   type t = {
     input: Input.t;
     stats: stats;
+    valid_subnets: Ipaddr.V4.Prefix.t list;
     valid_sources: Ipaddr.V4.t list;
   }
 
-  let connect ~valid_sources input =
+  let connect ~valid_subnets ~valid_sources input =
     let stats = {
       rx_bytes = 0L; rx_pkts = 0l; tx_bytes = 0L; tx_pkts = 0l;
     } in
-    Lwt.return (`Ok { input; stats; valid_sources })
+    Lwt.return (`Ok { input; stats; valid_subnets; valid_sources })
 
   let disconnect t = Input.disconnect t.input
   let after_disconnect t = Input.after_disconnect t.input
-  
+
   let write t buf = Input.write t.input buf
   let writev t bufs = Input.writev t.input bufs
 
-  let filter valid_sources next buf =
+  let filter valid_subnets valid_sources next buf =
     match (Wire_structs.parse_ethernet_frame buf) with
     | Some (Some Wire_structs.IPv4, _, payload) ->
       let src = Ipaddr.V4.of_int32 @@ Wire_structs.Ipv4_wire.get_ipv4_src payload in
-      if List.fold_left (fun acc valid -> acc || (Ipaddr.V4.compare src valid = 0)) false valid_sources
+      let from_valid_networks = List.fold_left (fun acc network -> acc || (Ipaddr.V4.Prefix.mem src network)) false valid_subnets in
+      let from_valid_sources = List.fold_left (fun acc valid -> acc || (Ipaddr.V4.compare src valid = 0)) false valid_sources in
+      if from_valid_sources || from_valid_networks
       then next buf
       else begin
         let src = Ipaddr.V4.to_string src in
@@ -48,23 +51,32 @@ module Make(Input: Sig.VMNET) = struct
           | Some `UDP ->
             let src_port = Wire_structs.get_udp_source_port body in
             let dst_port = Wire_structs.get_udp_dest_port body in
-            Log.warn (fun f -> f "dropping unexpected UDP packet sent from %s:%d to %s:%d (valid sources = %s)"
-              src src_port dst dst_port (String.concat ", " (List.map Ipaddr.V4.to_string valid_sources)))
+            Log.warn (fun f -> f "dropping unexpected UDP packet sent from %s:%d to %s:%d (valid subnets = %s; valid sources = %s)"
+              src src_port dst dst_port
+              (String.concat ", " (List.map Ipaddr.V4.Prefix.to_string valid_subnets))
+              (String.concat ", " (List.map Ipaddr.V4.to_string valid_sources))
+            )
           | Some `TCP ->
             let src_port = Wire_structs.Tcp_wire.get_tcp_src_port body in
             let dst_port = Wire_structs.Tcp_wire.get_tcp_dst_port body in
-            Log.warn (fun f -> f "dropping unexpected TCP packet sent from %s:%d to %s:%d (valid sources = %s)"
-              src src_port dst dst_port (String.concat ", " (List.map Ipaddr.V4.to_string valid_sources)))
+            Log.warn (fun f -> f "dropping unexpected TCP packet sent from %s:%d to %s:%d (valid subnets = %s; valid sources = %s)"
+              src src_port dst dst_port
+              (String.concat ", " (List.map Ipaddr.V4.Prefix.to_string valid_subnets))
+              (String.concat ", " (List.map Ipaddr.V4.to_string valid_sources))
+            )
           | _ ->
-            Log.warn (fun f -> f "dropping unknown IP protocol %d sent from %s to %s (valid sources = %s)"
-              (Wire_structs.Ipv4_wire.get_ipv4_proto payload) src dst  (String.concat ", " (List.map Ipaddr.V4.to_string valid_sources)))
+            Log.warn (fun f -> f "dropping unknown IP protocol %d sent from %s to %s (valid subnets = %s; valid sources = %s)"
+              (Wire_structs.Ipv4_wire.get_ipv4_proto payload) src dst
+              (String.concat ", " (List.map Ipaddr.V4.Prefix.to_string valid_subnets))
+              (String.concat ", " (List.map Ipaddr.V4.to_string valid_sources))
+            )
         end;
         Lwt.return ()
       end
     | _ -> next buf
 
-  let listen t callback = Input.listen t.input @@ filter t.valid_sources callback
-  let add_listener t callback = Input.add_listener t.input @@ filter t.valid_sources callback
+  let listen t callback = Input.listen t.input @@ filter t.valid_subnets t.valid_sources callback
+  let add_listener t callback = Input.add_listener t.input @@ filter t.valid_subnets t.valid_sources callback
 
   let mac t = Input.mac t.input
 

--- a/src/hostnet/lib/filter.mli
+++ b/src/hostnet/lib/filter.mli
@@ -2,7 +2,8 @@ module Make(Input: Sig.VMNET): sig
   include Sig.VMNET
 
   val connect:
-    valid_sources:Ipaddr.V4.t list -> Input.t
+    valid_subnets:Ipaddr.V4.Prefix.t list
+    -> valid_sources:Ipaddr.V4.t list -> Input.t
     -> [ `Ok of t | `Error of error ] Lwt.t
   (** Construct a filtered ethernet network which removes IP packets whose
       source IP is not in [valid_sources] *)

--- a/src/hostnet/lib/tcpip_stack.ml
+++ b/src/hostnet/lib/tcpip_stack.ml
@@ -64,22 +64,17 @@ let make ~client_macaddr ~server_macaddr ~peer_ip ~local_ip ~extra_dns_ip ~get_d
       Dhcp_wire.Broadcast_addr (Ipaddr.V4.Prefix.broadcast prefix);
       Dhcp_wire.Subnet_mask (Ipaddr.V4.Prefix.netmask prefix);
       Dhcp_wire.Domain_search domain_search;
-    ] in
-    let hyperkit : host = {
-      hostname = "hyperkit";
-      options = options;
-      hw_addr = Some client_macaddr;
-      fixed_addr = Some peer_ip;
-    } in {
+    ] in {
       options = options;
       hostname = "vpnkit"; (* it's us! *)
-      hosts = [ hyperkit ];
+      hosts = [ ];
       default_lease_time = Int32.of_int (60 * 60 * 2); (* 2 hours, from charrua defaults *)
       max_lease_time = Int32.of_int (60 * 60 * 24) ; (* 24 hours, from charrua defaults *)
       ip_addr = local_ip;
       mac_addr = server_macaddr;
       network = prefix;
-      range = (low_ip, high_ip);
+      (* FIXME: this needs https://github.com/haesbaert/charrua-core/pull/31 *)
+      range = (peer_ip, peer_ip); (* allow one dynamic client *)
     } in
   { peer_ip; local_ip; extra_dns_ip; prefix; server_macaddr; client_macaddr; get_dhcp_configuration }
 

--- a/src/hostnet/lib/tcpip_stack.ml
+++ b/src/hostnet/lib/tcpip_stack.ml
@@ -179,12 +179,13 @@ let or_error name m =
 
 let connect ~config (ppp: Vmnet.t) =
   let open Infix in
-  let valid_sources = [ config.peer_ip; Ipaddr.V4.of_string_exn "0.0.0.0" ] in
+  let valid_subnets = [ config.prefix ] in
+  let valid_sources = [ Ipaddr.V4.of_string_exn "0.0.0.0" ] in
   let arp_table = [
     config.peer_ip, config.client_macaddr;
     config.local_ip, config.server_macaddr;
   ] @ (List.map (fun ip -> ip, config.server_macaddr) config.extra_dns_ip) in
-  or_error "filter" @@ Netif.connect ~valid_sources ppp
+  or_error "filter" @@ Netif.connect ~valid_subnets ~valid_sources ppp
   >>= fun interface ->
   or_error "console" @@ Console_unix.connect "0"
   >>= fun console ->


### PR DESCRIPTION
Unfortunately switching the client from udhcpc to dhcpd causes a
problem because by default dhcpd will send a "duid" which charrua
doesn't recognise corresponds to the MAC address in the static
map. Since vpnkit currently only expects one client anyway,
switch to a dynamic range containing one element.

Signed-off-by: David Scott <dave.scott@docker.com>