### PR TITLE
Allow connection limit to be set via the database

### DIFF
--- a/src/com.docker.slirp/src/main.ml
+++ b/src/com.docker.slirp/src/main.ml
@@ -96,12 +96,12 @@ let hvsock_connect_forever url sockaddr callback =
   aux ()
 
 let start_port_forwarding port_control_url max_connections vsock_path =
-  Log.info (fun f -> f "starting port_forwarding port_control_url:%s max_connections:%s vsock_path:%s"
+  Log.info (fun f -> f "starting port_forwarding port_control_url:%s vsock_path:%s"
     port_control_url
-    (match max_connections with None -> "None" | Some x -> "Some " ^ (string_of_int x))
     vsock_path);
   (* Start the 9P port forwarding server *)
   Connect_unix.vsock_path := vsock_path;
+  (match max_connections with None -> () | Some _ -> Log.warn (fun f -> f "The argument max-connections is nolonger supported, use the database key slirp/max-connections instead"));
   Host.Sockets.set_max_connections max_connections;
 
   let uri = Uri.of_string port_control_url in
@@ -316,7 +316,7 @@ let port_control_path =
 let max_connections =
   let doc =
     Arg.info ~doc:
-      "Maximum number of concurrent forwarded connections" [ "max-connections" ]
+      "This argument is deprecated: use the database key slirp/max-connections instead." [ "max-connections" ]
   in
   Arg.(value & opt (some int) None doc)
 

--- a/src/hostnet/lib/host_lwt_unix.ml
+++ b/src/hostnet/lib/host_lwt_unix.ml
@@ -44,9 +44,16 @@ let register_connection_no_limit description =
   let idx = next_connection_idx () in
   Hashtbl.replace connection_table idx description;
   idx
-let register_connection description = match !max_connections with
+let register_connection =
+  let last_error_log = ref 0. in
+  fun description -> match !max_connections with
   | Some m when Hashtbl.length connection_table >= m ->
-    Log.err (fun f -> f "exceeded maximum number of forwarded connections (%d)" m);
+    let now = Unix.gettimeofday () in
+    if (now -. !last_error_log) > 30. then begin
+      (* Avoid hammering the logging system *)
+      Log.err (fun f -> f "exceeded maximum number of forwarded connections (%d)" m);
+      last_error_log := now;
+    end;
     Lwt.fail Too_many_connections
   | _ ->
     let idx = register_connection_no_limit description in


### PR DESCRIPTION
This is more flexible than the command-line which was being hardcoded
elsewhere. Note the command-line is still parsed but the value is ignored.
The help for the argument explains the path to the database key.

Signed-off-by: David Scott <dave.scott@docker.com>