### PR TITLE
dns: when closing one-shot connections, deregister them

### DIFF
--- a/src/hostnet/lib/host_uwt.ml
+++ b/src/hostnet/lib/host_uwt.ml
@@ -176,7 +176,7 @@ module Sockets = struct
                         Log.debug (fun f -> f "Socket.Datagram %s: expiring UDP NAT rule immediately" flow.description);
                         Hashtbl.remove table (src, src_port);
                         let _ = Uwt.Udp.close fd in
-                        ()
+                        deregister_connection idx
                       end;
                       flow.reply (Cstruct.sub buf 0 recv.Uwt.Udp.recv_len)
                       >>= fun () ->


### PR DESCRIPTION
Previously there was a missing interaction between the connection-tracking
PR and the one-shot DNS PR: when a one-shot DNS UDP rule was cleaned up,
the connection was leaked. This patch fixes the leak.

Signed-off-by: David Scott <dave.scott@docker.com>