### PR TITLE
Capture both sides of DNS transactions

### DIFF
--- a/src/hostnet/capture.mli
+++ b/src/hostnet/capture.mli
@@ -1,5 +1,6 @@
 module Make(Input: Sig.VMNET): sig
   include Sig.VMNET
+  include Sig.RECORDER with type t := t
 
   val connect: Input.t
     -> [ `Ok of t | `Error of error ] Lwt.t

--- a/src/hostnet/dns_forward.ml
+++ b/src/hostnet/dns_forward.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 
 let src =
   let src = Logs.Src.create "dns" ~doc:"Resolve DNS queries on the host" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -50,7 +50,7 @@ let lookup_locally = function
       ) None !(Hosts.etc_hosts) with
       | None -> None
       | Some v4 ->
-        Log.debug (fun f -> f "DNS[%04x] %s is %s in in /etc/hosts" id (Dns.Name.to_string q_name) (Ipaddr.V4.to_string v4));
+        Log.info (fun f -> f "DNS[%04x] %s is %s in in /etc/hosts" id (Dns.Name.to_string q_name) (Ipaddr.V4.to_string v4));
         let answers = [ { name = q_name; cls = RR_IN; flush = false; ttl = 0l; rdata = A v4 } ] in
         Some { Dns.Packet.id; detail; questions = request.questions; authorities=[]; additionals; answers }
       end
@@ -63,7 +63,7 @@ let lookup_locally = function
       ) None !(Hosts.etc_hosts) with
       | None -> None
       | Some v6 ->
-        Log.debug (fun f -> f "DNS[%04x] %s is %s in in /etc/hosts" id (Dns.Name.to_string q_name) (Ipaddr.V6.to_string v6));
+        Log.info (fun f -> f "DNS[%04x] %s is %s in in /etc/hosts" id (Dns.Name.to_string q_name) (Ipaddr.V6.to_string v6));
         let answers = [ { name = q_name; cls = RR_IN; flush = false; ttl = 0l; rdata = AAAA v6 } ] in
         Some { Dns.Packet.id; detail; questions = request.questions; authorities=[]; additionals; answers }
       end

--- a/src/hostnet/dns_forward.ml
+++ b/src/hostnet/dns_forward.ml
@@ -71,47 +71,102 @@ let lookup_locally = function
     end
   | _, _ -> None
 
-module Make(Ip: V1_LWT.IPV4) (Udp:V1_LWT.UDPV4) (Resolv_conf: Sig.RESOLV_CONF) (Socket: Sig.SOCKETS) (Time: V1_LWT.TIME) = struct
+module Make(Ip: V1_LWT.IPV4) (Udp:V1_LWT.UDPV4) (Resolv_conf: Sig.RESOLV_CONF) (Socket: Sig.SOCKETS) (Time: V1_LWT.TIME) (Recorder: Sig.RECORDER) = struct
 
 let choose_server ~nth () =
   Resolv_conf.get ()
   >>= fun all ->
   Lwt.return (choose_server ~nth all.Resolver.resolvers)
 
-let input ~nth ~udp ~src ~dst ~src_port buf =
+let record_udp ~source_ip ~source_port ~dest_ip ~dest_port ~recorder bufs =
+  (* This is from mirage-tcpip-- ideally we would use a simpler packet creation fn *)
+  let frame = Io_page.to_cstruct (Io_page.get 1) in
+  let smac = "\000\000\000\000\000\000" in
+  Wire_structs.set_ethernet_src smac 0 frame;
+  Wire_structs.set_ethernet_ethertype frame 0x0800;
+  let buf = Cstruct.shift frame Wire_structs.sizeof_ethernet in
+  Wire_structs.Ipv4_wire.set_ipv4_hlen_version buf ((4 lsl 4) + (5));
+  Wire_structs.Ipv4_wire.set_ipv4_tos buf 0;
+  Wire_structs.Ipv4_wire.set_ipv4_off buf 0;
+  Wire_structs.Ipv4_wire.set_ipv4_ttl buf 38;
+  let proto = Wire_structs.Ipv4_wire.protocol_to_int `UDP in
+  Wire_structs.Ipv4_wire.set_ipv4_proto buf proto;
+  Wire_structs.Ipv4_wire.set_ipv4_src buf (Ipaddr.V4.to_int32 source_ip);
+  Wire_structs.Ipv4_wire.set_ipv4_dst buf (Ipaddr.V4.to_int32 dest_ip);
+  let header_len = Wire_structs.sizeof_ethernet + Wire_structs.Ipv4_wire.sizeof_ipv4 in
+
+  let frame = Cstruct.set_len frame (header_len + Wire_structs.sizeof_udp) in
+  let udp_buf = Cstruct.shift frame header_len in
+  Wire_structs.set_udp_source_port udp_buf source_port;
+  Wire_structs.set_udp_dest_port udp_buf dest_port;
+  Wire_structs.set_udp_length udp_buf (Wire_structs.sizeof_udp + Cstruct.lenv bufs);
+  Wire_structs.set_udp_checksum udp_buf 0;
+  let csum = Ip.checksum frame (udp_buf :: bufs) in
+  Wire_structs.set_udp_checksum udp_buf csum;
+  (* Ip.writev *)
+  let bufs = frame :: bufs in
+  let tlen = Cstruct.lenv bufs - Wire_structs.sizeof_ethernet in
+  let dmac = String.make 6 '\000' in
+  (* Ip.adjust_output_header *)
+  Wire_structs.set_ethernet_dst dmac 0 frame;
+  let buf = Cstruct.sub frame Wire_structs.sizeof_ethernet Wire_structs.Ipv4_wire.sizeof_ipv4 in
+  (* Set the mutable values in the ipv4 header *)
+  Wire_structs.Ipv4_wire.set_ipv4_len buf tlen;
+  Wire_structs.Ipv4_wire.set_ipv4_id buf (Random.int 65535); (* TODO *)
+  Wire_structs.Ipv4_wire.set_ipv4_csum buf 0;
+  let checksum = Tcpip_checksum.ones_complement buf in
+  Wire_structs.Ipv4_wire.set_ipv4_csum buf checksum;
+  Recorder.record recorder bufs
+
+let input ~nth ~udp ~recorder ~src ~dst ~src_port buf =
   let src_str = Ipaddr.V4.to_string src in
   let dst_str = Ipaddr.V4.to_string dst in
+  (* src: the address of the VM
+     dst: the address of the DNS server i.e. us
+     remote: the address of the upstream DNS server *)
 
   let dns = parse_dns buf in
+  let userdesc = "DNS[" ^ (tidstr_of_dns dns) ^ "]" in
 
-  let reply buffer =
-    Log.debug (fun f -> f "DNS[%s] %s:%d <- %s (%s)" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns (parse_dns buffer)));
-    Udp.write ~source_port:53 ~dest_ip:src ~dest_port:src_port udp buffer in
-
-  Log.debug (fun f -> f "DNS[%s] %s:%d -> %s %s" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns dns));
+  Log.debug (fun f -> f "%s %s:%d -> %s %s" userdesc src_str src_port dst_str (string_of_dns dns));
   (* Is this an A or AAAA query which can be satisfied from /etc/hosts? *)
   match lookup_locally dns with
   | Some response ->
     let obuf = Dns.Buf.create 4096 in
     begin match Dns.Protocol.Server.marshal obuf response response with
     | None ->
-      Log.err (fun f -> f "DNS[%s] failed to marshal response" (tidstr_of_dns dns));
+      Log.err (fun f -> f "%s failed to marshal response" userdesc);
       Lwt.return_unit
     | Some buf ->
       let buf = Cstruct.of_bigarray buf in
-      reply buf
+      Log.debug (fun f -> f "%s %s:%d <- %s (%s)" userdesc src_str src_port dst_str (string_of_dns (parse_dns buf)));
+      Udp.write ~source_port:53 ~dest_ip:src ~dest_port:src_port udp buf
     end
   | None ->
     choose_server ~nth ()
     >>= function
-    | Some (dst_str, (dst, dst_port)) ->
-      Log.debug (fun f -> f "DNS[%s] Forwarding to %s (%s)" (tidstr_of_dns dns) (Ipaddr.to_string dst) dst_str);
+    | Some (remote_str, (remote, remote_port)) ->
+      Log.debug (fun f -> f "%s Forwarding to %s (%s)" userdesc (Ipaddr.to_string remote) remote_str);
+      (* Synthesize UDP packets and add then to the packet capture. This will
+         traverse the link to the VM which is unnecessary but DNS is low-bandwidth. *)
       let reply buffer =
-        Log.debug (fun f -> f "DNS[%s] %s:%d <- %s (%s)" (tidstr_of_dns dns) src_str src_port dst_str (string_of_dns (parse_dns buffer)));
+        Log.debug (fun f -> f "%s %s:%d <- %s (%s)" userdesc src_str src_port remote_str (string_of_dns (parse_dns buffer)));
+        begin match remote with
+        | Ipaddr.V4 remote ->
+          (* Synthesize a packet from the remote to the host i.e. dst *)
+          record_udp ~source_ip:remote ~source_port:remote_port ~dest_ip:dst ~dest_port:remote_port ~recorder [ buffer ]
+        | _ -> ()
+        end;
         Udp.write ~source_port:53 ~dest_ip:src ~dest_port:src_port udp buffer in
-      let userdesc = "DNS[" ^ (tidstr_of_dns dns) ^ "]" in
-      Socket.Datagram.input ~userdesc ~oneshot:true ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(dst, dst_port) ~payload:buf ()
+
+      begin match remote with
+      | Ipaddr.V4 remote ->
+        record_udp ~source_ip:dst ~source_port:remote_port ~dest_ip:remote ~dest_port:remote_port ~recorder [ buf ]
+      | _ -> ()
+      end;
+      Socket.Datagram.input ~userdesc ~oneshot:true ~reply ~src:(Ipaddr.V4 src, src_port) ~dst:(remote, remote_port) ~payload:buf ()
+
     | None ->
-      Log.err (fun f -> f "DNS[%s] No upstream DNS server configured: dropping request" (tidstr_of_dns dns));
+      Log.err (fun f -> f "%s No upstream DNS server configured: dropping request" userdesc);
       Lwt.return_unit
 end

--- a/src/hostnet/dns_forward.mli
+++ b/src/hostnet/dns_forward.mli
@@ -3,8 +3,9 @@ module Make
     (Udp: V1_LWT.UDPV4)
     (Resolv_conv: Sig.RESOLV_CONF)
     (Socket: Sig.SOCKETS)
-    (Time: V1_LWT.TIME) : sig
-  val input: nth:int -> udp:Udp.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
+    (Time: V1_LWT.TIME)
+    (Recorder: Sig.RECORDER) : sig
+  val input: nth:int -> udp:Udp.t -> recorder:Recorder.t -> src:Ipaddr.V4.t -> dst:Ipaddr.V4.t -> src_port:int -> Cstruct.t -> unit Lwt.t
 
   val choose_server: nth:int -> unit -> (string * (Ipaddr.t * int)) option Lwt.t
   (** [choose_server nth ()] chooses an upstream server to use from the

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -203,6 +203,15 @@ module type RESOLV_CONF = sig
   val set_default_dns: (Ipaddr.t * int) list -> unit
 end
 
+module type RECORDER = sig
+  (** Allow ethernet packets to be recorded *)
+
+  type t
+
+  val record: t -> Cstruct.t list -> unit
+  (** Inject a packet and record it if it matches a rule. This is intended for
+      debugging: the packet will not be transmitted to the underlying network. *)
+end
 
 module type Connector = sig
   (** Make connections into the VM *)


### PR DESCRIPTION
Previously we would only see the VM half of UDP DNS transactions, since `module Capture` is placed inline on the virtual ethernet link. This PR injects datagrams corresponding to UDP DNS activity on the host directly into the `module Capture` so the debug traces will show the query and response from the upstream server too.

Now that the DNS capturing is working well, the default log level of the `Dns_forwarder` can be raised from `Debug` to `Info`.