### PR TITLE
Update to new mirage-tcpip ICMPv4 interface

### DIFF
--- a/opam/darwin/packages/dev/tcpip.999/url
+++ b/opam/darwin/packages/dev/tcpip.999/url
@@ -1,1 +1,1 @@
-git: "git://github.com/djs55/mirage-tcpip#3.0.0-beta8"
+git: "git://github.com/djs55/mirage-tcpip#3.0.0-beta9"

--- a/src/_oasis
+++ b/src/_oasis
@@ -25,7 +25,7 @@ Library hostnet
     Forward, Host_lwt_unix, Host_uwt, Resolver, Hosts, Vmnet, Dhcp, Sig
   BuildDepends: cstruct, lwt.unix, logs, mirage-types.lwt, ipaddr, mirage-flow,
     ppx_sexp_conv, pcap-format, mirage-console.unix, tcpip.ethif,
-    tcpip.arpv4, tcpip.ipv4, tcpip.udp, tcpip.tcp, tcpip.stack-direct,
+    tcpip.arpv4, tcpip.ipv4, tcpip.icmpv4, tcpip.udp, tcpip.tcp, tcpip.stack-direct,
     charrua-core.server, dns, dns.lwt, ofs, uwt, uwt.ext, uwt.preemptive,
     lwt.preemptive, threads, astring, datakit-server.vfs
 

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -274,7 +274,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Resolv_conf: Sig.RESOLV_C
        when the do-not-fragment flag is set. *)
     let send_icmp_dst_unreachable t ~src ~dst ~src_port ~dst_port ~ihl raw =
       let would_fragment ~ip_header ~ip_payload =
-        let open Wire_structs.Ipv4_wire in
+        let open Icmpv4_wire in
         let header = Cstruct.create sizeof_icmpv4 in
         set_icmpv4_ty header 0x03;
         set_icmpv4_code header 0x04;


### PR DESCRIPTION
This pulls in the patches from [mirage/mirage-tcpip#193] so we're closer to the APIs provided by tcpip.2.8.1 (although we're not quite there yet)

Signed-off-by: David Scott <dave.scott@docker.com>