### PR TITLE
Allow the DHCP server domain name to be overriden

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -235,6 +235,7 @@ let main_t socket_url port_control_url introspection_url max_connections vsock_p
       local_ip = Ipaddr.V4.of_string_exn "192.168.65.1";
       extra_dns_ip = [];
       get_domain_search = (fun () -> []);
+      get_domain_name = (fun () -> "local");
       pcap_settings = Active_config.Value(pcap, never) } in
 
   let config = match db_path with

--- a/src/hostnet/dhcp.ml
+++ b/src/hostnet/dhcp.ml
@@ -30,7 +30,8 @@ module Make(Netif: V1_LWT.NETWORK) = struct
     | hd::tl -> List.fold_left (fun acc x -> if compare acc x > 0 then acc else x) hd tl
 
   (* given some MACs and IPs, construct a usable DHCP configuration *)
-  let make ~client_macaddr ~server_macaddr ~peer_ip ~local_ip ~extra_dns_ip ~get_domain_search netif =
+  let make ~client_macaddr ~server_macaddr ~peer_ip ~local_ip ~extra_dns_ip
+    ~get_domain_search ~get_domain_name netif =
     let open Dhcp_server.Config in
     (* FIXME: We need a DHCP range to make the DHCP server happy, even though we
        intend only to serve IPs to one downstream host.
@@ -53,7 +54,7 @@ module Make(Netif: V1_LWT.NETWORK) = struct
         ) (Name.Map.empty, 0, buffer) (get_domain_search ()) in
         Cstruct.(to_string (sub buffer 0 n)) in
       let options = [
-        Dhcp_wire.Domain_name "local";
+        Dhcp_wire.Domain_name (get_domain_name ());
         Dhcp_wire.Routers [ local_ip ];
         Dhcp_wire.Dns_servers (local_ip :: extra_dns_ip);
         Dhcp_wire.Ntp_servers [ local_ip ];

--- a/src/hostnet/dhcp.mli
+++ b/src/hostnet/dhcp.mli
@@ -7,6 +7,7 @@ module Make(Netif: V1_LWT.NETWORK): sig
   val make: client_macaddr:Macaddr.t -> server_macaddr:Macaddr.t
     -> peer_ip: Ipaddr.V4.t -> local_ip:Ipaddr.V4.t
     -> extra_dns_ip:Ipaddr.V4.t list -> get_domain_search:(unit -> string list)
+    -> get_domain_name:(unit -> string)
     -> Netif.t -> t
 
   val callback: t -> Cstruct.t -> unit Lwt.t

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -706,6 +706,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
           let open Dns_forward in
           begin match Config.of_string txt with
           | Result.Ok config ->
+            domain_search := config.Config.search;
             Lwt.return (Some config)
           | Result.Error (`Msg m) ->
             Log.err (fun f -> f "failed to parse %s: %s" (String.concat "/" dns_path) m);

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -9,6 +9,7 @@ type config = {
   local_ip: Ipaddr.V4.t;
   extra_dns_ip: Ipaddr.V4.t list;
   get_domain_search: unit -> string list;
+  get_domain_name: unit -> string;
   pcap_settings: pcap Active_config.values;
 }
 (** A slirp TCP/IP stack ready to accept connections *)

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -92,6 +92,7 @@ let config =
     local_ip = Ipaddr.V4.of_string_exn "192.168.65.1";
     extra_dns_ip;
     get_domain_search = (fun () -> []);
+    get_domain_name = (fun () -> "local");
     pcap_settings = Active_config.Value(None, never);
   }
 

--- a/src/ofs/active_config.ml
+++ b/src/ofs/active_config.ml
@@ -38,6 +38,13 @@ let rec map f = function Value(first, next) ->
     map f next in
   return (Value(first', next'))
 
+let rec iter f = function Value(first, next) ->
+  f first
+  >>= fun () ->
+  next
+  >>= fun next ->
+  iter f next
+
 type path = string list
 
 let changes values =

--- a/src/ofs/active_config.mli
+++ b/src/ofs/active_config.mli
@@ -10,6 +10,9 @@ val tl: 'a values -> 'a values Lwt.t
 val map: ('a -> 'b Lwt.t) -> 'a values -> 'b values Lwt.t
 (** Transform an infinite stream of values *)
 
+val iter: ('a -> unit Lwt.t) -> 'a values -> unit Lwt.t
+(** Iterate over all values in the stream *)
+
 type path = string list
 
 module type S = sig


### PR DESCRIPTION
Previously the DHCP server hardcoded the domain name to `local`. This PR allows the domain name to be overriden via the database key `slirp/domain`.

Note this PR also contains a bug fix to the very similar search domain override mechanism. Ideally I'd add a unit test for this but it's a bit tricky using the built-in DHCP client in `tcpip.2.8.0` which doesn't seem to expose the information.