### PR TITLE
Include the Mac binary in the artefact, not a dangling symlink

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -24,7 +24,7 @@ clean:
 
 stage:
 	mkdir -p _build/root/Contents/MacOS
-	mv main.native com.docker.slirp
+	cp main.native com.docker.slirp
 	mv com.docker.slirp _build/root/Contents/MacOS/com.docker.slirp
 	dylibbundler -od -b \
 	  -x _build/root/Contents/MacOS/com.docker.slirp \


### PR DESCRIPTION
Previously the `mv main.native` simply moved the symlink to the binary
into the staging area. Using `cp main.native` means the symlink should
be followed and the contents copied instead.

Signed-off-by: David Scott <dave.scott@docker.com>