### PR TITLE
Reduce spammy logging

### DIFF
--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -280,7 +280,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
                          Mirage_flow.proxy (module Clock) (module Stack_tcp) flow (module Host.Sockets.Stream.Tcp) socket ()
                          >>= function
                          | `Error (`Msg m) ->
-                           Log.err (fun f -> f "%s proxy failed with %s" (Tcp.Flow.to_string t) m);
+                           Log.debug (fun f -> f "%s proxy failed with %s" (Tcp.Flow.to_string t) m);
                            Lwt.return_unit
                          | `Ok (_l_stats, _r_stats) ->
                            Lwt.return_unit

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -23,7 +23,7 @@ let log_exception_continue description f =
   Lwt.catch
     (fun () -> f ())
     (fun e ->
-       Log.err (fun f -> f "%s: caught %s" description (Printexc.to_string e));
+       Log.debug (fun f -> f "%s: caught %s" description (Printexc.to_string e));
        Lwt.return ()
     )
 
@@ -263,7 +263,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
           Host.Sockets.Stream.Tcp.connect (ip, port)
           >>= function
           | Result.Error (`Msg m) ->
-            Log.err (fun f -> f "%s:%d: failed to connect, sending RST: %s" (Ipaddr.to_string ip) port m);
+            Log.debug (fun f -> f "%s:%d: failed to connect, sending RST: %s" (Ipaddr.to_string ip) port m);
             Lwt.return (fun _ -> None)
           | Result.Ok socket ->
             let t = Tcp.Flow.create id socket in

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -2,7 +2,7 @@ open Lwt
 
 let src =
   let src = Logs.Src.create "usernet" ~doc:"Mirage TCP/IP <-> socket proxy" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)


### PR DESCRIPTION
@samoht observed a recent test run generated 227MiB of log files, mostly "Errors" explaining that the remote server refused a connection (as it is totally at liberty to do)

This PR:
- increases minimum debug level to Info (was debug)
- downgrades some "errors" to "debug"