### PR TITLE
Re-enable testing

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -33,3 +33,4 @@ make depends
 make
 make OSS-LICENSES
 make COMMIT
+make test

--- a/circle.yml
+++ b/circle.yml
@@ -23,4 +23,4 @@ dependencies:
   - make COMMIT
 test:
   override:
-  - echo Dummy test
+  - make test


### PR DESCRIPTION
Previously the tests became disabled in CI when we moved from installing
hostnet via `opam install -t` to a simpler oasis/Makefile.

This patch adds `make test` to circle.yml and appveyor.sh

Signed-off-by: David Scott <dave.scott@docker.com>