### PR TITLE
Udp: fix packet overwriting bug in listen

### DIFF
--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -400,11 +400,12 @@ module Sockets = struct
           end
 
       let listen t flow_cb =
-        let buffer = Cstruct.create Constants.max_udp_length in
         let rec loop () =
           Lwt.catch
             (fun () ->
-              (* Lwt on Win32 doesn't support Lwt_bytes.recvfrom *)
+              (* Allocate a fresh buffer because the packet will be processed
+                 in a background thread *)
+              let buffer = Cstruct.create Constants.max_udp_length in
               recvfrom t buffer
               >>= fun (n, address) ->
               let data = Cstruct.sub buffer 0 n in


### PR DESCRIPTION
Previously the `listen` loop allocated a buffer and called `recvfrom`
to read a UDP datagram. The flow callback was called asynchronously
with a reference to this buffer, so the next `recvfrom` could overwrite
the contents.

This patch uses a fresh buffer per `recvfrom` which avoids accidentally
overwriting a previous packet.

Signed-off-by: David Scott <dave.scott@docker.com>