### PR TITLE
Uwt: remove an unnecessary `deregister_connection`

### DIFF
--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -268,7 +268,6 @@ module Sockets = struct
              if not(Uwt.Int_result.is_ok result) then begin
                let error = Uwt.Int_result.to_error result in
                Log.err (fun f -> f "Socket.%s.connect(%s): %s" label (string_of_address address) (Uwt.strerror error));
-               deregister_connection idx;
                Lwt.fail (Unix.Unix_error(Uwt.to_unix_error error, "bind", ""))
              end else Lwt_result.return (of_fd ~idx ?read_buffer_size ~description sockaddr address fd)
           )


### PR DESCRIPTION
Previously we deregistered the connection and then called `Lwt.fail`.
Since we're in the middle of an `Lwt.catch`, control passes to the
exception handler which calls `deregister_connection` again. In most
cases this logs a benign error but it some cases we might deregister
some other connection which could cause the connection limiting to
underestimate the total number of active connections.

Signed-off-by: David Scott <dave.scott@docker.com>