### PR TITLE
test: add explicit 10s timeouts for most of the tests

### DIFF
--- a/src/_oasis
+++ b/src/_oasis
@@ -29,17 +29,29 @@ Library hostnet
     charrua-core.server, dns, dns.lwt, ofs, uwt, uwt.ext, uwt.preemptive,
     lwt.preemptive, threads, astring, datakit-server.vfs, dns-forward, tar
 
-Executable test
+Executable test_lwt
   Path: hostnet_test
   CompiledObject: best
-  MainIs: main.ml
+  MainIs: main_lwt.ml
   Build$: flag(tests)
   BuildDepends: hostnet, cmdliner, alcotest, lwt.unix, logs.fmt,
-    dns.mirage, lwt.preemptive, uwt.preemptive
+    dns.mirage, lwt.preemptive
 
-Test test
+Executable test_uwt
+  Path: hostnet_test
+  CompiledObject: best
+  MainIs: main_uwt.ml
+  Build$: flag(tests)
+  BuildDepends: hostnet, cmdliner, alcotest, logs.fmt, dns.mirage, uwt.preemptive
+
+Test test_lwt
   Run$:               flag(tests)
-  Command:            $test -q
+  Command:            $test_lwt -q
+  WorkingDirectory:   hostnet_test
+
+Test test_uwt
+  Run$:               flag(tests)
+  Command:            $test_uwt -q
   WorkingDirectory:   hostnet_test
 
 Library ofs

--- a/src/hostnet_test/forwarding.ml
+++ b/src/hostnet_test/forwarding.ml
@@ -14,6 +14,10 @@ let (>>*=) m f = m >>= function
 
 module Make(Host: Sig.HOST) = struct
 
+let run ?(timeout=60.) t =
+  let timeout = Host.Time.sleep timeout >>= fun () -> Lwt.fail (Failure "timeout") in
+  Host.Main.run @@ Lwt.pick [ timeout; t ]
+
 module Channel = Channel.Make(Host.Sockets.Stream.Tcp)
 
 module ForwardServer = struct
@@ -269,7 +273,7 @@ let test_one_forward () =
               )
           )
       ) in
-  Host.Main.run t
+  run t
 
 let test_10_connections () =
   let t =
@@ -305,7 +309,7 @@ let test_10_connections () =
               )
           )
       ) in
-  Host.Main.run t
+  run t
 
 let test = [
   "Test one port forward", `Quick, test_one_forward;

--- a/src/hostnet_test/main_lwt.ml
+++ b/src/hostnet_test/main_lwt.ml
@@ -1,0 +1,26 @@
+open Hostnet
+open Lwt.Infix
+
+let src =
+  let src = Logs.Src.create "test" ~doc:"Test the slirp stack" in
+  Logs.Src.set_level src (Some Logs.Debug);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Tests = Suite.Make(Host_lwt_unix)
+
+let tests =
+  (List.map (fun (name, test) -> name ^ " with Lwt", test) Tests.suite) @
+  Hosts_test.suite
+
+(* Run it *)
+let () =
+  Logs.set_reporter (Logs_fmt.reporter ());
+  Lwt.async_exception_hook := (fun exn ->
+    Log.err (fun f -> f "Lwt.async failure %s: %s"
+      (Printexc.to_string exn)
+      (Printexc.get_backtrace ())
+    )
+  );
+  Alcotest.run "Hostnet" tests

--- a/src/hostnet_test/main_uwt.ml
+++ b/src/hostnet_test/main_uwt.ml
@@ -1,0 +1,26 @@
+open Hostnet
+open Lwt.Infix
+
+let src =
+  let src = Logs.Src.create "test" ~doc:"Test the slirp stack" in
+  Logs.Src.set_level src (Some Logs.Debug);
+  src
+
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Tests = Suite.Make(Host_uwt)
+
+let tests =
+  (List.map (fun (name, test) -> name ^ " with Uwt", test) Tests.suite) @
+  Hosts_test.suite
+
+(* Run it *)
+let () =
+  Logs.set_reporter (Logs_fmt.reporter ());
+  Lwt.async_exception_hook := (fun exn ->
+    Log.err (fun f -> f "Lwt.async failure %s: %s"
+      (Printexc.to_string exn)
+      (Printexc.get_backtrace ())
+    )
+  );
+  Alcotest.run "Hostnet" tests

--- a/src/hostnet_test/nat.ml
+++ b/src/hostnet_test/nat.ml
@@ -10,6 +10,10 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 module Make(Host: Sig.HOST) = struct
 
+  let run ?(timeout=60.) t =
+    let timeout = Host.Time.sleep timeout >>= fun () -> Lwt.fail (Failure "timeout") in
+    Host.Main.run @@ Lwt.pick [ timeout; t ]
+
   module Slirp_stack = Slirp_stack.Make(Host)
   open Slirp_stack
 
@@ -114,7 +118,7 @@ module Make(Host: Sig.HOST) = struct
                 loop 5
              )
         ) in
-    Host.Main.run t
+    run t
 
   (* Start a local UDP mult-echo server, send traffic to it from one source port,
      wait for the response, send traffic to it from another source port, expect
@@ -164,7 +168,7 @@ module Make(Host: Sig.HOST) = struct
                 loop 5
              )
         ) in
-    Host.Main.run t
+    run t
 
   (* Start a local UDP echo server, send some traffic to it over the virtual interface.
      Send traffic to the outside address on a second physical interface, check that
@@ -218,7 +222,7 @@ module Make(Host: Sig.HOST) = struct
                 loop 5
              )
         ) in
-    Host.Main.run t
+    run t
 
   (* The NAT table rule should be associated with the virtual address, rather
      than physical address. Check if we have 2 physical servers we have only a
@@ -271,7 +275,7 @@ module Make(Host: Sig.HOST) = struct
                   )
              )
         ) in
-    Host.Main.run t
+    run t
 
   let suite = [
     "Shared NAT rule", `Quick, test_shared_nat_rule;

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -315,22 +315,3 @@ let suite = [
   "UDP", N.suite;
 ]
 end
-
-module Slirp_lwt_unix = Make(Host_lwt_unix)
-module Slirp_uwt = Make(Host_uwt)
-
-let tests =
-  (List.map (fun (name, test) -> name ^ " with Lwt_unix", test) Slirp_lwt_unix.suite) @
-  (List.map (fun (name, test) -> name ^ " with Uwt", test) Slirp_uwt.suite) @
-  Hosts_test.suite
-
-(* Run it *)
-let () =
-  Logs.set_reporter (Logs_fmt.reporter ());
-  Lwt.async_exception_hook := (fun exn ->
-    Log.err (fun f -> f "Lwt.async failure %s: %s"
-      (Printexc.to_string exn)
-      (Printexc.get_backtrace ())
-    )
-  );
-  Alcotest.run "Hostnet" tests


### PR DESCRIPTION
Previously the tests could block forever, particularly infuriating as
this locks the appveyor CI slot for 1hr. All the tests should execute
within 10s, except the max connections one which has been given a 4
minute maximum.

Signed-off-by: David Scott <dave.scott@docker.com>