### PR TITLE
Trim or demote spammy errors

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -105,10 +105,12 @@ let hvsock_connect_forever url sockaddr callback =
   aux ()
 
 let start_introspection introspection_url root =
-  Lwt.async (fun () ->
-    log_exception_continue "start_introspection_server"
+  if introspection_url = ""
+  then Log.info (fun f -> f "no introspection server requested. See the --introspection argument")
+  else Lwt.async (fun () ->
+    log_exception_continue ("starting introspection server on: " ^ introspection_url)
       (fun () ->
-        Log.info (fun f -> f "starting introspection intrspection_url:%s" introspection_url);
+        Log.info (fun f -> f "starting introspection server on: %s" introspection_url);
         let module Server = Fs9p.Make(Host.Sockets.Stream.Unix) in
         unix_listen introspection_url
         >>= fun s ->
@@ -127,10 +129,12 @@ let start_introspection introspection_url root =
   )
 
 let start_diagnostics diagnostics_url flow_cb =
-  Lwt.async (fun () ->
-    log_exception_continue "start_diagnostics_server"
+  if diagnostics_url = ""
+  then Log.info (fun f -> f "no diagnostics server requested. See the --diagnostics argument")
+  else Lwt.async (fun () ->
+    log_exception_continue ("starting diagnostics server on: " ^ diagnostics_url)
       (fun () ->
-        Log.info (fun f -> f "starting diagnostics diagnostics_url:%s" diagnostics_url);
+        Log.info (fun f -> f "starting diagnostics server on: %s" diagnostics_url);
         unix_listen diagnostics_url
         >>= fun s ->
         Host.Sockets.Stream.Unix.listen s flow_cb;
@@ -139,7 +143,7 @@ let start_diagnostics diagnostics_url flow_cb =
   )
 
 let start_port_forwarding port_control_url max_connections vsock_path =
-  Log.info (fun f -> f "starting port_forwarding port_control_url:%s vsock_path:%s"
+  Log.info (fun f -> f "starting port forwarding server on port_control_url:%s vsock_path:%s"
     port_control_url
     vsock_path);
   (* Start the 9P port forwarding server *)

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -17,11 +17,18 @@ let src =
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
+let _ =
+  Printexc.register_printer (function
+    | Unix.Unix_error(e, _, _) -> Some (Unix.error_message e)
+    | Uwt.Uwt_error(e, _, _) -> Some (Uwt.strerror e)
+    | e -> None
+  )
+
 let log_exception_continue description f =
   Lwt.catch
     (fun () -> f ())
     (fun e ->
-       Log.err (fun f -> f "%s: caught %s" description (Printexc.to_string e));
+       Log.err (fun f -> f "%s: failed with %s" description (Printexc.to_string e));
        Lwt.return ()
     )
 

--- a/src/hostnet/arp.ml
+++ b/src/hostnet/arp.ml
@@ -26,7 +26,7 @@
 
 let src =
   let src = Logs.Src.create "arp" ~doc:"fixed ARP table" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/hostnet/arp.ml
+++ b/src/hostnet/arp.ml
@@ -56,11 +56,11 @@ module Make(Ethif: V1_LWT.ETHIF) = struct
   let get_ips t = List.map fst (Table.bindings t.table)
   let add_ip t ip =
     let mac = Ethif.mac t.ethif in
-    Log.info (fun f -> f "ARP: adding %s -> %s" (Ipaddr.V4.to_string ip) (Macaddr.to_string mac));
+    Log.debug (fun f -> f "ARP: adding %s -> %s" (Ipaddr.V4.to_string ip) (Macaddr.to_string mac));
     Lwt.return_unit
   let set_ips t ips = Lwt_list.iter_s (add_ip t) ips
   let remove_ip t ip =
-    Log.info (fun f -> f "ARP: removing %s" (Ipaddr.V4.to_string ip));
+    Log.debug (fun f -> f "ARP: removing %s" (Ipaddr.V4.to_string ip));
     t.table <- Table.remove ip t.table;
     Lwt.return_unit
   let query t ip =

--- a/src/hostnet/forward.ml
+++ b/src/hostnet/forward.ml
@@ -270,6 +270,7 @@ let start_udp_proxy description vsock_path_var remote_port server =
         Lwt.return true
       ) (function
         | Unix.Unix_error(Unix.EBADF, _, _) -> Lwt.return false
+        | Uwt.Uwt_error(Uwt.ECANCELED, _, _) -> Lwt.return false
         | e ->
           Log.err (fun f -> f "%s: shutting down recvfrom thread: %s" description (Printexc.to_string e));
           Lwt.return false

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -236,7 +236,7 @@ module Sockets = struct
         let t = make ~idx ~label fd in
         if not(Uwt.Int_result.is_ok result) then begin
           let error = Uwt.Int_result.to_error result in
-          Log.err (fun f -> f "Socket.%s.bind(%s, %d): %s" t.label (Ipaddr.to_string ip) port (Uwt.strerror error));
+          Log.debug (fun f -> f "Socket.%s.bind(%s, %d): %s" t.label (Ipaddr.to_string ip) port (Uwt.strerror error));
           deregister_connection idx;
           Lwt.fail (Unix.Unix_error(Uwt.to_unix_error error, "bind", ""))
         end else Lwt.return t
@@ -516,7 +516,7 @@ module Sockets = struct
             end
           | Uwt.Error error ->
             let msg = Printf.sprintf "Socket.%s.bind(%s, %d): %s" label (Ipaddr.to_string ip) port (Uwt.strerror error) in
-            Log.err (fun f -> f "Socket.%s.bind: %s" label msg);
+            Log.debug (fun f -> f "Socket.%s.bind: %s" label msg);
             deregister_connection idx;
             Lwt.fail (Unix.Unix_error(Uwt.to_unix_error error, "bind", "")) )
         >>= fun local_port ->

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -528,7 +528,7 @@ module Sockets = struct
              if Ipaddr.compare ip (Ipaddr.V4 Ipaddr.V4.localhost) = 0
              || Ipaddr.compare ip (Ipaddr.V4 Ipaddr.V4.any) = 0
              then begin
-               Log.info (fun f -> f "attempting a best-effort bind of ::1:%d" local_port);
+               Log.debug (fun f -> f "attempting a best-effort bind of ::1:%d" local_port);
                bind_one (Ipaddr.(V6 V6.localhost), local_port)
                >>= fun (idx, _, fd) ->
                Lwt.return [ idx, fd ]
@@ -536,7 +536,7 @@ module Sockets = struct
                Lwt.return []
              end
           ) (fun e ->
-              Log.info (fun f -> f "ignoring failed bind to ::1:%d (%s)" local_port (Printexc.to_string e));
+              Log.debug (fun f -> f "ignoring failed bind to ::1:%d (%s)" local_port (Printexc.to_string e));
               Lwt.return []
             )
         >>= fun extra ->

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -422,9 +422,12 @@ module Sockets = struct
                let results = Cstruct.sub t.read_buffer 0 n in
                t.read_buffer <- Cstruct.shift t.read_buffer n;
                Lwt.return (`Ok results)
-          ) (fun e ->
-              Log.err (fun f -> f "Socket.%s.read %s: caught %s returning Eof" t.label t.description (Printexc.to_string e));
-              Lwt.return `Eof
+          ) (function
+              | Uwt.Uwt_error(Uwt.ECANCELED, _, _) ->
+                Lwt.return `Eof
+              | e ->
+                Log.err (fun f -> f "Socket.%s.read %s: caught %s returning Eof" t.label t.description (Printexc.to_string e));
+                Lwt.return `Eof
             )
 
       let write t buf =

--- a/src/hostnet/hostnet_udp.ml
+++ b/src/hostnet/hostnet_udp.ml
@@ -3,7 +3,7 @@ open Lwt.Infix
 
 let src =
   let src = Logs.Src.create "Uwt" ~doc:"UDP NAT implementation" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/hostnet/mux.ml
+++ b/src/hostnet/mux.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 
 let src =
   let src = Logs.Src.create "mux" ~doc:"Mirage TCP/IP <-> socket proxy" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -845,7 +845,9 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
         let ip_opts = List.map
             (fun x ->
                try
-                 Some (Ipaddr.of_string_exn x)
+                 if x = ""
+                 then None
+                 else Some (Ipaddr.of_string_exn x)
                with _ ->
                  Log.err (fun f -> f "Failed to parse IP address in allowed-bind-address: %s" x);
                  None

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -871,7 +871,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
         Lwt.return default
       | Some x -> Lwt.return x in
     let parse_ipv4_list default x =
-      let all = List.map (fun x -> Ipaddr.V4.of_string @@ String.trim x) @@ Astring.String.cuts ~sep:"," x in
+      let all = List.map Ipaddr.V4.of_string @@ List.filter (fun x -> x <> "") @@ List.map String.trim @@ Astring.String.cuts ~sep:"," x in
       let any_none, some = List.fold_left (fun (any_none, some) x -> match x with
           | None -> true, some
           | Some x -> any_none, x :: some

--- a/src/hostnet/vmnet.ml
+++ b/src/hostnet/vmnet.ml
@@ -218,12 +218,12 @@ let server_negotiate t =
       let open Lwt_result.Infix in
       Lwt.return (Command.unmarshal buf)
       >>= fun (command, _) ->
-      Log.info (fun f -> f "PPP.negotiate: received %s" (Command.to_string command));
+      Log.debug (fun f -> f "PPP.negotiate: received %s" (Command.to_string command));
       let vif = Vif.create t.client_macaddr () in
       let buf = Cstruct.create Vif.sizeof in
       let (_: Cstruct.t) = Vif.marshal vif buf in
       let open Lwt.Infix in
-      Log.info (fun f -> f "PPP.negotiate: sending %s" (Vif.to_string vif));
+      Log.debug (fun f -> f "PPP.negotiate: sending %s" (Vif.to_string vif));
       Channel.write_buffer fd buf;
       Channel.flush fd
       >>= fun () ->
@@ -260,7 +260,7 @@ let client_negotiate t =
       let open Lwt_result.Infix in
       Lwt.return (Vif.unmarshal buf)
       >>= fun (vif, _) ->
-      Log.info (fun f -> f "Client.negotiate: vif %s" (Vif.to_string vif));
+      Log.debug (fun f -> f "Client.negotiate: vif %s" (Vif.to_string vif));
       Lwt_result.return ()
     )
 
@@ -351,7 +351,7 @@ let disconnect t = match t.fd with
   | None -> Lwt.return ()
   | Some fd ->
     t.fd <- None;
-    Log.info (fun f -> f "Vmnet.disconnect flushing channel");
+    Log.debug (fun f -> f "Vmnet.disconnect flushing channel");
     Channel.flush fd
     >>= fun () ->
     Lwt.wakeup_later t.after_disconnect_u ();
@@ -420,7 +420,7 @@ let writev t bufs =
 
 let listen t callback =
   if t.listening then begin
-    Log.info (fun f -> f "PPP.listen: called a second time: doing nothing");
+    Log.debug (fun f -> f "PPP.listen: called a second time: doing nothing");
     Lwt.return ();
   end else begin
     t.listening <- true;
@@ -463,7 +463,7 @@ let listen t callback =
            Lwt_result.return true
         ) (function
             | End_of_file ->
-              Log.info (fun f -> f "PPP.listen: closing connection");
+              Log.debug (fun f -> f "PPP.listen: closing connection");
               Lwt_result.return false
             | e ->
               Log.err (fun f -> f "PPP.listen: caught unexpected %s: disconnecting" (Printexc.to_string e));

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -308,10 +308,10 @@ module F = Forwarding.Make(Host)
 module N = Nat.Make(Host)
 
 let suite = [
+  "Forwarding", F.test;
   "DHCP", test_dhcp;
   "DNS UDP", test_dns;
   "TCP", test_tcp;
-  "Forwarding", F.test;
   "UDP", N.suite;
 ]
 end

--- a/src/ofs/active_list.ml
+++ b/src/ofs/active_list.ml
@@ -335,7 +335,7 @@ The directory will be deleted and replaced with a file of the same name.
       active := StringMap.add name entry !active;
       let resource = Entry entry in
       connection.fids :=  Types.Fid.Map.add fid resource !(connection.fids);
-      Log.info (fun f -> f "Creating resource %s" (string_of_resource resource));
+      Log.debug (fun f -> f "Creating resource %s" (string_of_resource resource));
       return { Response.Create.qid; iounit = 512l }
     | resource ->
       Log.err (fun f -> f "EPERM creating resource = %s"
@@ -343,7 +343,7 @@ The directory will be deleted and replaced with a file of the same name.
       Error.eperm
 
   let write connection ~cancel:_ { Request.Write.fid; offset; data } =
-    Log.info (fun f -> f "Write offset=%Ld data=[%s] to file" offset (Cstruct.to_string data));
+    Log.debug (fun f -> f "Write offset=%Ld data=[%s] to file" offset (Cstruct.to_string data));
     let ok = { Response.Write.count = Int32.of_int @@ Cstruct.len data } in
     try
       let resource = Types.Fid.Map.find fid !(connection.fids) in
@@ -359,7 +359,7 @@ The directory will be deleted and replaced with a file of the same name.
             | Result.Ok f' -> (* local_port is resolved *)
               entry.instance <- Some f';
               entry.result <- Some ("OK " ^ (Instance.to_string f') ^ "\n");
-              Log.info (fun f -> f "Created instance %s" (Instance.to_string f'));
+              Log.debug (fun f -> f "Created instance %s" (Instance.to_string f'));
               return ok
             | Result.Error (`Msg m) ->
               Log.err (fun f -> f "Failed to start instance: %s" m);

--- a/src/ofs/active_list.ml
+++ b/src/ofs/active_list.ml
@@ -362,7 +362,6 @@ The directory will be deleted and replaced with a file of the same name.
               Log.debug (fun f -> f "Created instance %s" (Instance.to_string f'));
               return ok
             | Result.Error (`Msg m) ->
-              Log.err (fun f -> f "Failed to start instance: %s" m);
               entry.result <- Some ("ERROR " ^ m ^ "\n");
               return ok
           end


### PR DESCRIPTION
The goal is to remove as many "expected" logs which are emitted with severity "error", so it becomes possible to grep the logs for "ERROR" and see something meaningful.

Fixes #108 