### PR TITLE
Add a patch to ocaml-dns to fix the resource-record parsing

### DIFF
--- a/opam/darwin/packages/dev/dns.999/descr
+++ b/opam/darwin/packages/dev/dns.999/descr
@@ -1,0 +1,5 @@
+DNS client and server implementation
+
+This is a pure OCaml implementation of the DNS protocol. It is intended to be a
+reasonably high-performance implementation, but clarity is preferred rather
+than low-level performance hacks.

--- a/opam/darwin/packages/dev/dns.999/opam
+++ b/opam/darwin/packages/dev/dns.999/opam
@@ -1,0 +1,67 @@
+opam-version: "1.2"
+maintainer: "anil@recoil.org"
+authors: [
+  "Anil Madhavapeddy"
+  "Tim Deegan"
+  "Richard Mortier"
+  "Haris Rotsos"
+  "David Sheets"
+  "Thomas Gazagnaire"
+  "Luke Dunstan"
+  "David Scott"
+]
+homepage: "https://github.com/mirage/ocaml-dns"
+bug-reports: "https://github.com/mirage/ocaml-dns/issues"
+license: "ISC"
+tags: ["org:mirage" "org:xapi-project"]
+dev-repo: "https://github.com/mirage/ocaml-dns.git"
+build: [
+  [
+    "ocaml"
+    "setup.ml"
+    "-configure"
+    "--prefix"
+    prefix
+    "--%{base-unix:enable}%-lwt"
+    "--%{mirage-types:enable}%-mirage"
+  ]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: ["ocaml" "setup.ml" "-install"]
+build-test: [
+  [
+    "ocaml"
+    "setup.ml"
+    "-configure"
+    "--prefix"
+    prefix
+    "--%{base-unix:enable}%-lwt"
+    "--%{mirage-types:enable}%-mirage"
+    "--enable-tests"
+  ]
+  ["ocaml" "setup.ml" "-build"]
+  ["ocaml" "setup.ml" "-test" "-runner" "sequential"]
+]
+remove: ["ocamlfind" "remove" "dns"]
+depends: [
+  "ocamlfind" {build}
+  "base-bytes"
+  "lwt" {>= "2.4.7"}
+  "cstruct" {>= "1.0.1"}
+  "ppx_tools"
+  "re"
+  "cmdliner"
+  "ipaddr" {>= "2.6.0"}
+  "uri" {>= "1.7.0"}
+  "base64" {>= "2.0.0"}
+  "mirage-profile"
+  "hashcons"
+  "ounit" {test}
+  "pcap-format" {test}
+]
+depopts: ["async" "base-unix" "mirage-types"]
+conflicts: [
+  "mirage-types" {< "1.2.0"}
+  "async" {< "112.24.00"}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/opam/darwin/packages/dev/dns.999/url
+++ b/opam/darwin/packages/dev/dns.999/url
@@ -1,0 +1,1 @@
+git: "https://github.com/djs55/ocaml-dns.git#v0.18.1-parse-fix"

--- a/opam/darwin/packages/local/slirp.local/opam
+++ b/opam/darwin/packages/local/slirp.local/opam
@@ -25,7 +25,7 @@ depends: [
   "uwt" {= "0.0.3"}
   "tcpip" { = "999" }
   "pcap-format"
-  "dns"
+  "dns" { = "999" }
   "dns-forward"
   "datakit-server"
   "hashcons" {= "1.0.1"}

--- a/opam/win32/packages/dev/dns.999
+++ b/opam/win32/packages/dev/dns.999
@@ -1,0 +1,1 @@
+../../../darwin/packages/dev/dns.999


### PR DESCRIPTION
This is a port of

    https://github.com/mirage/ocaml-dns/pull/109

Signed-off-by: David Scott <dave.scott@docker.com>