### PR TITLE
Improve Makefile, Dockerfile and opam

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,9 @@
 FROM ocaml/opam:alpine
-RUN sudo apk add --update ncurses
 ADD . /home/opam/src
-RUN sudo chown -R opam /home/opam/src/
-RUN opam repo add dev /home/opam/src
-RUN opam pin add -y -n proto-vmnet /home/opam/src/src/proto-vmnet
-RUN opam pin add -y -n ofs /home/opam/src/src/ofs
-RUN opam pin add -y -n hostnet /home/opam/src/src/hostnet
-RUN opam pin add -y -n osx-daemon /home/opam/src/src/osx-daemon
-RUN opam depext -u proto-vmnet
-RUN opam depext -u ofs
-RUN opam depext -u hostnet
-RUN opam install -j 2 -v -y proto-vmnet
-RUN opam install -j 2 -v -y ofs
-RUN opam install -j 2 -v -y hostnet
+# Latest packages plus some overrides are in this repo:
+RUN opam remote add vpnkit /home/opam/src/repo/darwin
+RUN opam pin add -y -n vpnkit /home/opam/src
+RUN opam depext vpnkit -y
+RUN opam install --deps-only vpnkit -y
+RUN opam pin remove vpnkit
+WORKDIR /home/opam/src

--- a/opam
+++ b/opam
@@ -21,9 +21,7 @@ build: [
   [make]
 ]
 build-test: [
-  ["oasis" "setup"]
-  ["./configure" "--enable-tests"]
-  ["ocaml" "setup.ml" "-test"]
+  [make "test"]
 ]
 install: [make "install" "BINDIR=%{bin}%"]
 remove: [make "uninstall" "BINDIR=%{bin}%"]

--- a/opam
+++ b/opam
@@ -29,9 +29,10 @@ install: [make "install" "BINDIR=%{bin}%"]
 remove: [make "uninstall" "BINDIR=%{bin}%"]
 
 depends: [
-  "ocamlfind" {build}
+  "ocamlfind"  {build}
   "ocamlbuild" {build}
-  "oasis" {build}
+  "oasis"      {build}
+  "alcotest"   {test}
   "result"
   "tar-format"
   "ipaddr"
@@ -56,6 +57,4 @@ depends: [
   "astring"
   "mirage-flow" { >= "1.1.0" }
   "mirage-types-lwt"
-  "ounit"
-  "alcotest"
 ]

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -33,5 +33,6 @@ OPAMVERBOSE=1 opam reinstall tcpip -y -t
 
 OPAMVERBOSE=1 make
 OPAMVERBOSE=1 make test
+OPAMVERBOSE=1 make artefacts
 OPAMVERBOSE=1 make OSS-LICENSES
 OPAMVERBOSE=1 make COMMIT


### PR DESCRIPTION
- default `make` targets now work on Linux (should fix build error https://travis-ci.org/ocaml/opam-repository/builds/178430928)
- `Dockerfile` refreshed to new repo structure
- remove `ounit` from `opam`
- `alcotest` is a test dependency in `opam`