### PR TITLE
Reduce log spam even further

### DIFF
--- a/src/bin/bind.ml
+++ b/src/bin/bind.ml
@@ -2,7 +2,7 @@ module Lwt_result = Hostnet.Hostnet_lwt_result (* remove when new Lwt is release
 
 let src =
   let src = Logs.Src.create "port forward" ~doc:"forward local ports to the VM" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/bin/connect.ml
+++ b/src/bin/connect.ml
@@ -1,6 +1,6 @@
 let src =
   let src = Logs.Src.create "port forward" ~doc:"forward local ports to the VM" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -12,7 +12,7 @@ module Log9P = (val Logs.src_log src : Logs.LOG)
 
 let src =
   let src = Logs.Src.create "usernet" ~doc:"Mirage TCP/IP <-> socket proxy" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/hostnet/capture.ml
+++ b/src/hostnet/capture.ml
@@ -1,6 +1,6 @@
 let src =
   let src = Logs.Src.create "capture" ~doc:"capture network traffic" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/hostnet/dhcp.ml
+++ b/src/hostnet/dhcp.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 
 let src =
   let src = Logs.Src.create "dhcp" ~doc:"Mirage TCP/IP" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/hostnet/filter.ml
+++ b/src/hostnet/filter.ml
@@ -1,6 +1,6 @@
 let src =
   let src = Logs.Src.create "ppp" ~doc:"point-to-point network link" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/hostnet/forward.ml
+++ b/src/hostnet/forward.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 
 let src =
   let src = Logs.Src.create "port forward" ~doc:"forward local ports to the VM" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)
@@ -284,7 +284,6 @@ let start_udp_proxy description vsock_path_var remote_port server =
           read v
           >>= function
           | None ->
-            Log.debug (fun f -> f "%s: shutting down from vsock thread: UDP stream desychronised" description);
             Lwt.return false
           | Some (buf, address) ->
             Socket.Datagram.Udp.sendto fd address buf

--- a/src/hostnet/host_lwt_unix.ml
+++ b/src/hostnet/host_lwt_unix.ml
@@ -4,7 +4,7 @@ open Lwt.Infix
 
 let src =
   let src = Logs.Src.create "Lwt_unix" ~doc:"Host interface based on Lwt_unix" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -4,7 +4,7 @@ open Lwt.Infix
 
 let src =
   let src = Logs.Src.create "Uwt" ~doc:"Host interface based on Uwt" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)

--- a/src/hostnet/hosts.ml
+++ b/src/hostnet/hosts.ml
@@ -2,7 +2,7 @@ open Lwt.Infix
 
 let src =
   let src = Logs.Src.create "/etc/hosts" ~doc:"monitor and read the /etc/hosts file" in
-  Logs.Src.set_level src (Some Logs.Debug);
+  Logs.Src.set_level src (Some Logs.Info);
   src
 
 module Log = (val Logs.src_log src : Logs.LOG)


### PR DESCRIPTION
This PR bumps the minimum logging threshold from `Debug` to `Info`. Previously the Mac ASL reporter would omit `Debug` messages anyway, but they would still be printed on Windows. Hopefully this makes Windows as quiet as the Mac.