### PR TITLE
Use the correct Unix.inet_addr matching the PF in bind

### DIFF
--- a/src/hostnet/host_lwt_unix.ml
+++ b/src/hostnet/host_lwt_unix.ml
@@ -169,12 +169,12 @@ module Datagram = struct
       let description = "udp:" ^ (string_of_address address) in
       register_connection description
       >>= fun idx ->
-      let pf = match fst address with
-        | Ipaddr.V4 _ -> Lwt_unix.PF_INET
-        | Ipaddr.V6 _ -> Lwt_unix.PF_INET6 in
+      let pf, addr = match fst address with
+        | Ipaddr.V4 _ -> Lwt_unix.PF_INET, Unix.inet_addr_any
+        | Ipaddr.V6 _ -> Lwt_unix.PF_INET6, Unix.inet6_addr_any in
       let fd = Lwt_unix.socket pf Lwt_unix.SOCK_DGRAM 0 in
       (* Win32 requires all sockets to be bound however macOS and Linux don't *)
-      (try Lwt_unix.bind fd (Lwt_unix.ADDR_INET(Unix.inet_addr_any, 0)) with _ -> ());
+      (try Lwt_unix.bind fd (Lwt_unix.ADDR_INET(addr, 0)) with _ -> ());
       let sockaddr = sockaddr_of_address address in
       Lwt.return (Result.Ok (of_fd ~idx ~description ?read_buffer_size sockaddr address fd))
 

--- a/src/hostnet/host_uwt.ml
+++ b/src/hostnet/host_uwt.ml
@@ -133,15 +133,15 @@ module Sockets = struct
         let description = "udp:" ^ (string_of_address address) in
         register_connection description
         >>= fun idx ->
-        let label, fd =
+        let label, fd, addr =
           try match fst @@ address with
-            | Ipaddr.V4 _ -> "UDPv4", Uwt.Udp.init_ipv4_exn ()
-            | Ipaddr.V6 _ -> "UDPv6", Uwt.Udp.init_ipv6_exn ()
+            | Ipaddr.V4 _ -> "UDPv4", Uwt.Udp.init_ipv4_exn (), Unix.inet_addr_any
+            | Ipaddr.V6 _ -> "UDPv6", Uwt.Udp.init_ipv6_exn (), Unix.inet6_addr_any
           with e -> deregister_connection idx; raise e in
         Lwt.catch
           (fun () ->
              let sockaddr = make_sockaddr address in
-             let result = Uwt.Udp.bind fd ~addr:(Unix.ADDR_INET(Unix.inet_addr_any, 0)) () in
+             let result = Uwt.Udp.bind fd ~addr:(Unix.ADDR_INET(addr, 0)) () in
              if not(Uwt.Int_result.is_ok result) then begin
                let error = Uwt.Int_result.to_error result in
                Log.err (fun f -> f "Socket.%s.connect(%s): %s" label (string_of_address address) (Uwt.strerror error));


### PR DESCRIPTION
The Unix.inet_addr type includes both IPv4 and IPv6. When we send
traffic over UDP we first bind the socket to "any". Previously we
used the value `Unix.inet_addr_any` but this is IPv4-only. This patch
selects either `Unix.inet_addr_any` or `Unix.inet6_addr_any`.

Signed-off-by: David Scott <dave.scott@docker.com>