### PR TITLE
opam: depend on lwt < 3.0.0

### DIFF
--- a/opam
+++ b/opam
@@ -34,7 +34,7 @@ depends: [
   "result"
   "tar-format"
   "ipaddr"
-  "lwt"
+  "lwt" { < "3.0.0" }
   "uwt" { = "0.0.3" }
   "tcpip" { >= "2.8.0" & < "3.0.0" }
   "pcap-format"


### PR DESCRIPTION
We need to use the new versioned `Lwt_unix.bind` interface in future.

Signed-off-by: David Scott <dave.scott@docker.com>