### PR TITLE
Fix parsing of /etc/hosts

### DIFF
--- a/src/hostnet/hosts.ml
+++ b/src/hostnet/hosts.ml
@@ -29,9 +29,9 @@ let of_string txt =
             | ' ' | '\n' | '\011' | '\012' | '\r' | '\t' -> true
             | _ -> false in
           match String.fields ~empty:false ~is_sep:whitespace line with
-          | [ addr; name ] ->
+          | addr :: names ->
             begin match Ipaddr.of_string addr with
-            | Some addr -> (name, addr) :: acc
+            | Some addr -> List.map (fun name -> (name, addr)) names @ acc
             | None ->
               Log.err (fun f -> f "Failed to parse address '%s' from hosts file" addr);
               acc

--- a/src/hostnet_test/hosts_test.ml
+++ b/src/hostnet_test/hosts_test.ml
@@ -17,10 +17,11 @@ let examples = [
     "# localhost is used to configure the loopback interface";
     "# when the system is booting.  Do not change this entry.";
     "##";
-    "127.0.0.1      	localhost";
+    "127.0.0.1      	localhost mylocalhostalias";
     "255.255.255.255	broadcasthost";
     "::1             localhost";
   ], [
+  "mylocalhostalias", Ipaddr.V4 Ipaddr.V4.localhost;
   "localhost", Ipaddr.V4 Ipaddr.V4.localhost;
   "broadcasthost", Ipaddr.of_string_exn "255.255.255.255";
   "localhost", Ipaddr.of_string_exn "::1";

--- a/src/hostnet_test/hosts_test.ml
+++ b/src/hostnet_test/hosts_test.ml
@@ -30,6 +30,10 @@ let examples = [
 
 let test_one txt expected () =
   let x = Hostnet.Hosts.of_string txt in
+  let expected' = List.length expected in
+  let x' = List.length x in
+  if expected' <> x'
+  then failwith (Printf.sprintf "Expected %d hosts in /etc/hosts but found %d" expected' x');
   List.iter (fun ((a_name, a_ip), (b_name, b_ip)) ->
     if Ipaddr.compare a_ip b_ip <> 0 then failwith "IP doesn't match";
     if a_name <> b_name then failwith "name doesn't match"

--- a/src/hostnet_test/main_lwt.ml
+++ b/src/hostnet_test/main_lwt.ml
@@ -11,7 +11,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module Tests = Suite.Make(Host_lwt_unix)
 
 let tests =
-  (List.map (fun (name, test) -> name ^ " with Lwt", test) Tests.suite) @
+  (List.map (fun (name, test) -> name ^ "_with_Lwt", test) Tests.suite) @
   Hosts_test.suite
 
 (* Run it *)

--- a/src/hostnet_test/main_uwt.ml
+++ b/src/hostnet_test/main_uwt.ml
@@ -11,7 +11,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 module Tests = Suite.Make(Host_uwt)
 
 let tests =
-  (List.map (fun (name, test) -> name ^ " with Uwt", test) Tests.suite) @
+  (List.map (fun (name, test) -> name ^ "_with_Uwt", test) Tests.suite) @
   Hosts_test.suite
 
 (* Run it *)

--- a/src/hostnet_test/suite.ml
+++ b/src/hostnet_test/suite.ml
@@ -307,7 +307,7 @@ let test_tcp = [
 module F = Forwarding.Make(Host)
 module N = Nat.Make(Host)
 
-let suite = [
+let suite = Hosts_test.suite @ [
   "Forwarding", F.test;
   "DHCP", test_dhcp;
   "DNS UDP", test_dns;


### PR DESCRIPTION
Previously we would fail to parse lines which included extra aliases, for example we would fail to parse:
```
127.0.0.1 localhost mylocalhostalias
```

This PR fixes the parser and adds a test.