### PR TITLE
Avoid using `detach` for port forwarding

### DIFF
--- a/src/bin/connect.ml
+++ b/src/bin/connect.ml
@@ -44,7 +44,9 @@ module Make_unix(Host: Sig.HOST) = struct
 end
 
 module Make_hvsock(Host: Sig.HOST) = struct
-  module F = Flow_lwt_hvsock_shutdown.Make(Host.Time)(Host.Fn)
+  (* Avoid using `detach` because we don't want to exhaust the
+     thread pool since this will block the main TCP/IP stack. *)
+  module F = Flow_lwt_hvsock_shutdown.Make(Host.Time)(Lwt_hvsock_main_thread.Make(Host.Main))
 
   type flow = {
     idx: int;


### PR DESCRIPTION
The Lwt_preemptive and Uwt_preemptive thread pools have a fixed
maximim size, typically 4. The main TCP/IP stack needs to be able
to acquire one of these workers or else it blocks. This patch
stops using `detach` in the port forwarding path, so that incoming
port forwards don't break the main network.

Signed-off-by: David Scott <dave.scott@docker.com>