### PR TITLE
Increase the MTU on the virtual ethernet link

### DIFF
--- a/repo/darwin/packages/dev/mirage-types-lwt.2.8.999/descr
+++ b/repo/darwin/packages/dev/mirage-types-lwt.2.8.999/descr
@@ -1,0 +1,14 @@
+Lwt module type definitions for Mirage-compatible applications
+
+This is a virtual package that pulls in all the concrete
+dependencies required for the `mirage-types.lwt` ocamlfind
+package to become available.
+
+The purpose of this library is to provide concrete types
+for several that are left abstract in `mirage-types`:
+
+- `type 'a io = 'a Lwt.t`
+- `type page_aligned_buffer = Io_page.t`
+- `type buffer = Cstruct.t`
+- `type macaddr = Macaddr.t`
+- `type ipv4addr = Ipaddr.V4.t`

--- a/repo/darwin/packages/dev/mirage-types-lwt.2.8.999/opam
+++ b/repo/darwin/packages/dev/mirage-types-lwt.2.8.999/opam
@@ -1,0 +1,16 @@
+opam-version: "1.2"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "https://github.com/mirage/mirage.git"
+tags:         ["org:mirage" "org:xapi-project"]
+
+depends: [
+  "ocamlfind"
+  "lwt"
+  "cstruct" {>="1.4.0"}
+  "io-page" {>="1.4.0"}
+  "ipaddr"
+  "mirage-types" {="2.8.999"}
+]

--- a/repo/darwin/packages/dev/mirage-types.2.8.999/descr
+++ b/repo/darwin/packages/dev/mirage-types.2.8.999/descr
@@ -1,0 +1,1 @@
+Module type definitions for Mirage-compatible applications

--- a/repo/darwin/packages/dev/mirage-types.2.8.999/opam
+++ b/repo/darwin/packages/dev/mirage-types.2.8.999/opam
@@ -1,0 +1,20 @@
+opam-version: "1.2"
+maintainer:   ["anil@recoil.org" "thomas@gazagnaire.org"]
+authors:      "The MirageOS team"
+homepage:     "https://github.com/mirage/mirage"
+bug-reports:  "https://github.com/mirage/mirage/issues/"
+dev-repo:     "https://github.com/mirage/mirage.git"
+tags:         ["org:mirage" "org:xapi-project"]
+
+build:   [make "build-types"]
+install: [make "install-types"]
+remove:  ["ocamlfind" "remove" "mirage-types"]
+
+depends: [
+  "ocamlfind"
+  "ocamlbuild" {build}
+]
+depopts:   ["lwt" "cstruct" "io-page" "ipaddr"]
+conflicts: ["ipaddr" {< "2.0.0"}]
+
+available: [ocaml-version >= "4.01.0"]

--- a/repo/darwin/packages/dev/mirage-types.2.8.999/url
+++ b/repo/darwin/packages/dev/mirage-types.2.8.999/url
@@ -1,0 +1,1 @@
+git: "git://github.com/djs55/mirage#2.8.0-mtu"

--- a/repo/darwin/packages/dev/tcpip.999/url
+++ b/repo/darwin/packages/dev/tcpip.999/url
@@ -1,1 +1,1 @@
-git: "git://github.com/djs55/mirage-tcpip#3.0.0-beta10"
+git: "git://github.com/djs55/mirage-tcpip#3.0.0-beta11"

--- a/repo/darwin/packages/local/slirp.local/opam
+++ b/repo/darwin/packages/local/slirp.local/opam
@@ -41,7 +41,7 @@ depends: [
   "fmt"
   "astring"
   "mirage-flow" { >= "1.1.0" }
-  "mirage-types-lwt" { >= "2.8.0" & <"3.0.0" }
+  "mirage-types-lwt" { = "2.8.999" }
   "ounit"
   "alcotest"
 ]

--- a/repo/licenses/LICENSE.mirage-types-lwt.2.8.999
+++ b/repo/licenses/LICENSE.mirage-types-lwt.2.8.999
@@ -1,0 +1,24 @@
+(*
+ * Copyright (c) 2011-2014 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2011-2015 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2013      Citrix Systems Inc
+ * Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2013 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2013-2014 Citrix Systems Inc
+ * Copyright (c) 2013-2014 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2013-2015 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2014 David Sheets <sheets@alum.mit.edu>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+

--- a/repo/licenses/LICENSE.mirage-types.2.8.999
+++ b/repo/licenses/LICENSE.mirage-types.2.8.999
@@ -1,0 +1,24 @@
+(*
+ * Copyright (c) 2011-2014 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2011-2015 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2013      Citrix Systems Inc
+ * Copyright (c) 2013 Anil Madhavapeddy <anil@recoil.org>
+ * Copyright (c) 2013 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2013-2014 Citrix Systems Inc
+ * Copyright (c) 2013-2014 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2013-2015 Thomas Gazagnaire <thomas@gazagnaire.org>
+ * Copyright (c) 2014 David Sheets <sheets@alum.mit.edu>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *)
+

--- a/repo/win32/packages/dev/mirage-types-lwt.2.8.999
+++ b/repo/win32/packages/dev/mirage-types-lwt.2.8.999
@@ -1,0 +1,1 @@
+../../../darwin/packages/dev/mirage-types-lwt.2.8.999

--- a/repo/win32/packages/dev/mirage-types.2.8.999
+++ b/repo/win32/packages/dev/mirage-types.2.8.999
@@ -1,0 +1,1 @@
+../../../darwin/packages/dev/mirage-types.2.8.999/

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -265,7 +265,8 @@ let main_t socket_url port_control_url introspection_url diagnostics_url max_con
       extra_dns_ip = [];
       get_domain_search = (fun () -> []);
       get_domain_name = (fun () -> "local");
-      pcap_settings = Active_config.Value(pcap, never) } in
+      pcap_settings = Active_config.Value(pcap, never);
+      mtu = 1500; } in
 
   let config = match db_path with
     | Some db_path ->

--- a/src/hostnet/capture.ml
+++ b/src/hostnet/capture.ml
@@ -216,7 +216,7 @@ module Make(Input: Sig.VMNET) = struct
     t.stats.rx_pkts <- 0l;
     t.stats.tx_pkts <- 0l
 
-  let of_fd ~client_macaddr:_ ~server_macaddr:_ =
+  let of_fd ~client_macaddr:_ ~server_macaddr:_ ~mtu:_ =
     failwith "Capture.of_fd unimplemented"
 
   let start_capture _ ?size_limit:_ _ =

--- a/src/hostnet/filter.ml
+++ b/src/hostnet/filter.ml
@@ -104,7 +104,7 @@ module Make(Input: Sig.VMNET) = struct
     t.stats.rx_pkts <- 0l;
     t.stats.tx_pkts <- 0l
 
-  let of_fd ~client_macaddr:_ ~server_macaddr:_ =
+  let of_fd ~client_macaddr:_ ~server_macaddr:_ ~mtu:_ =
     failwith "Filter.of_fd unimplemented"
 
   let start_capture _ ?size_limit:_ _ =

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -190,7 +190,7 @@ module type VMNET = sig
   type fd
 
   val of_fd: client_macaddr:Macaddr.t -> server_macaddr:Macaddr.t
-    -> fd -> t Error.t
+    -> mtu:int -> fd -> t Error.t
 
   val start_capture: t -> ?size_limit:int64 -> string -> unit Lwt.t
 

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -23,7 +23,9 @@ let default_dns_extra = []
    to respect the Do Not Fragment bit. *)
 let safe_outgoing_mtu = 1452 (* packets above this size with DNF set will get ICMP errors *)
 
-let default_mtu = 1500 (* used for the virtual ethernet link *)
+(* The default MTU is limited by the maximum message size on a Hyper-V socket.
+   On currently available windows versions, we need to stay below 8192 bytes *)
+let default_mtu = 8000 (* used for the virtual ethernet link *)
 
 let log_exception_continue description f =
   Lwt.catch

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -11,6 +11,7 @@ type config = {
   get_domain_search: unit -> string list;
   get_domain_name: unit -> string;
   pcap_settings: pcap Active_config.values;
+  mtu: int;
 }
 (** A slirp TCP/IP stack ready to accept connections *)
 

--- a/src/hostnet/vmnet.mli
+++ b/src/hostnet/vmnet.mli
@@ -13,13 +13,13 @@ val after_disconnect: t -> unit Lwt.t
 
 val add_listener: t -> (Cstruct.t -> unit Lwt.t) -> unit
 
-val of_fd: client_macaddr:Macaddr.t -> server_macaddr:Macaddr.t -> C.flow -> t Error.t
-(** [of_fd ~client_macaddr ~server_macaddr fd] negotiates with the client over
+val of_fd: client_macaddr:Macaddr.t -> server_macaddr:Macaddr.t -> mtu:int -> C.flow -> t Error.t
+(** [of_fd ~client_macaddr ~server_macaddr ~mtu fd] negotiates with the client over
     [fd]. The client uses [client_macaddr] as the source address of all its ethernet
     frames. The server uses [server_macaddr] as the source address of all its
-    ethernet frames. *)
+    ethernet frames and sets the MTU to [mtu]. *)
 
-val client_of_fd: client_macaddr:Macaddr.t -> server_macaddr:Macaddr.t -> C.flow -> t Error.t
+val client_of_fd: client_macaddr:Macaddr.t -> server_macaddr:Macaddr.t -> mtu:int -> C.flow -> t Error.t
 
 val start_capture: t -> ?size_limit:int64 -> string -> unit Lwt.t
 (** [start_capture t ?size_limit filename] closes any existing pcap capture

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -97,6 +97,7 @@ let config =
     get_domain_search = (fun () -> []);
     get_domain_name = (fun () -> "local");
     pcap_settings = Active_config.Value(None, never);
+    mtu = 1500;
   }
 
 (* This is a hacky way to get a hancle to the server side of the stack. *)
@@ -143,7 +144,7 @@ let with_stack f =
   Log.info (fun f -> f "Made a loopback connection");
   let client_macaddr = Hostnet.Slirp.client_macaddr in
   let server_macaddr = Hostnet.Slirp.server_macaddr in
-  VMNET.client_of_fd ~client_macaddr:server_macaddr ~server_macaddr:client_macaddr flow
+  VMNET.client_of_fd ~client_macaddr:server_macaddr ~server_macaddr:client_macaddr ~mtu:1500 flow
   >>= function
   | Result.Error (`Msg x ) ->
     (* Server will close when it gets EOF *)


### PR DESCRIPTION
This PR separates the MTU used for outgoing datagram traffic (for which we need to respect the Do Not Fragment bit) from the MTU used on the internal virtual ethernet link and bumps the latter to 8000. This should allow the TCP stack to use a larger segment size and to reduce the overhead per byte of payload.

This PR also allows the virtual ethernet MTU to be set via the database key `com.docker.driver.amd64-linux/slirp/mtu`

Note this PR references a port of https://github.com/mirage/mirage-protocols/pull/4 and https://github.com/mirage/mirage-tcpip/pull/288 but we need to do some rebasing work for the v3 release anyway.