### PR TITLE
Only capture the first 128 bytes of traffic

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -265,7 +265,6 @@ let main_t socket_url port_control_url introspection_url diagnostics_url max_con
       extra_dns_ip = [];
       get_domain_search = (fun () -> []);
       get_domain_name = (fun () -> "local");
-      pcap_settings = Active_config.Value(pcap, never);
       mtu = 1500; } in
 
   let config = match db_path with

--- a/src/hostnet/capture.mli
+++ b/src/hostnet/capture.mli
@@ -7,7 +7,7 @@ module Make(Input: Sig.VMNET): sig
   (** Capture traffic from a network, match against a set of capture rules
       and keep a limited amount of the most recent traffic that matches. *)
 
-  val add_match: t:t -> name:string -> limit:int -> predicate:(Frame.t -> bool) -> unit
+  val add_match: t:t -> name:string -> limit:int -> snaplen:int -> predicate:(Frame.t -> bool) -> unit
   (** Start capturing traffic which matches a given rule *)
 
   val filesystem: t -> Vfs.Dir.t

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -628,9 +628,9 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
     let kib = 1024 in
     let mib = 1024 * kib in
     (* Capture 1 MiB of all traffic *)
-    Netif.add_match ~t:interface ~name:"all.pcap" ~limit:mib ~predicate:(fun _ -> true);
+    Netif.add_match ~t:interface ~name:"all.pcap" ~limit:mib ~snaplen:1500 ~predicate:(fun _ -> true);
     (* Capture 256 KiB of DNS traffic *)
-    Netif.add_match ~t:interface ~name:"dns.pcap" ~limit:(256 * kib) ~predicate:is_dns;
+    Netif.add_match ~t:interface ~name:"dns.pcap" ~limit:(256 * kib) ~snaplen:1500 ~predicate:is_dns;
 
     Switch.connect interface
     >>= fun switch ->

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -626,9 +626,8 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
     Dns_forwarder.set_recorder interface;
 
     let kib = 1024 in
-    let mib = 1024 * kib in
     (* Capture 1 MiB of all traffic *)
-    Netif.add_match ~t:interface ~name:"all.pcap" ~limit:mib ~snaplen:1500 ~predicate:(fun _ -> true);
+    Netif.add_match ~t:interface ~name:"all.pcap" ~limit:(256 * kib) ~snaplen:128 ~predicate:(fun _ -> true);
     (* Capture 256 KiB of DNS traffic *)
     Netif.add_match ~t:interface ~name:"dns.pcap" ~limit:(256 * kib) ~snaplen:1500 ~predicate:is_dns;
 

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -10,7 +10,6 @@ type config = {
   extra_dns_ip: Ipaddr.V4.t list;
   get_domain_search: unit -> string list;
   get_domain_name: unit -> string;
-  pcap_settings: pcap Active_config.values;
   mtu: int;
 }
 (** A slirp TCP/IP stack ready to accept connections *)

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -96,7 +96,6 @@ let config =
     extra_dns_ip;
     get_domain_search = (fun () -> []);
     get_domain_name = (fun () -> "local");
-    pcap_settings = Active_config.Value(None, never);
     mtu = 1500;
   }
 


### PR DESCRIPTION
For debugging we maintain a fixed amount of captured traffic which can be accessed via diagnostic commands. Previously we would keep entire packets. This patch limits the capture to 128 bytes per packet which is enough for most headers (including, for example, enough for TCP stream analysis) but omits most of the payloads.