### PR TITLE
Derive a `max_packet_size` from the MTU

### DIFF
--- a/src/hostnet/vmnet.ml
+++ b/src/hostnet/vmnet.ml
@@ -120,7 +120,7 @@ module Vif = struct
   let to_string t = Sexplib.Sexp.to_string (sexp_of_t t)
 
   let create client_macaddr mtu () =
-    let max_packet_size = 1550 in
+    let max_packet_size = mtu + 50 in
     { mtu; max_packet_size; client_macaddr }
 
   let sizeof = sizeof_msg


### PR DESCRIPTION
Historically this value from vmnet.framework was around 1550, or mtu + 50. This patch restores the link with the MTU.

Without this, some packets are erroneously truncated and dropped.

Signed-off-by: David Scott <dave.scott@docker.com>