### PR TITLE
Backport DNS parser pointer to pointer fixes

### DIFF
--- a/repo/darwin/packages/dev/dns.999/url
+++ b/repo/darwin/packages/dev/dns.999/url
@@ -1,1 +1,1 @@
-git: "https://github.com/djs55/ocaml-dns.git#v0.18.1-parse-fix"
+git: "https://github.com/djs55/ocaml-dns.git#v0.18.1-parse-fixes"


### PR DESCRIPTION
This is a backport of

https://github.com/mirage/ocaml-dns/pull/129

onto the v0.18.1 stable branch used by vpnkit.

Signed-off-by: David Scott <dave.scott@docker.com>