### PR TITLE
Capture less debug traffic

### DIFF
--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -626,8 +626,6 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
     Dns_forwarder.set_recorder interface;
 
     let kib = 1024 in
-    (* Capture 1 MiB of all traffic *)
-    Netif.add_match ~t:interface ~name:"all.pcap" ~limit:(256 * kib) ~snaplen:128 ~predicate:(fun _ -> true);
     (* Capture 256 KiB of DNS traffic *)
     Netif.add_match ~t:interface ~name:"dns.pcap" ~limit:(256 * kib) ~snaplen:1500 ~predicate:is_dns;
 


### PR DESCRIPTION
Previously we collected a sample of general traffic for debugging but
this hasn't been particularly useful. This patch removes this generic
capture but leaves in the DNS-specific capture which is still useful.

Signed-off-by: David Scott <dave.scott@docker.com>