### PR TITLE
Rename default artifact to match repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ _build/
 *~
 COMMIT
 OSS-LICENSES
-com.docker.slirp
-com.docker.slirp.tgz
+vpnkit
+vpnkit.tgz
 opam/licenses/dependency.slirp
 _tags
 configure

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ BINDIR?=$(shell pwd)
 BINARIES :=
 ARTEFACTS :=
 ifeq ($(OS),Windows_NT)
-	BINARIES += com.docker.slirp.exe
-	ARTEFACTS += com.docker.slirp.exe
+	BINARIES += vpnkit.exe
+	ARTEFACTS += vpnkit.exe
 else
-	BINARIES += com.docker.slirp
-	ARTEFACTS += com.docker.slirp.tgz
+	BINARIES += vpnkit
+	ARTEFACTS += vpnkit.tgz
 endif
 
 all: $(BINARIES)
@@ -36,24 +36,24 @@ src/bin/depends.ml: src/bin/depends.ml.in
 	cp src/bin/depends.ml src/bin/depends.tmp
 	sed -e 's/££HVSOCK_PINNED££/$(shell opam info hvsock -f pinned)/g' src/bin/depends.tmp > src/bin/depends.ml
 
-com.docker.slirp.tgz: com.docker.slirp
+vpnkit.tgz: vpnkit
 	mkdir -p _build/root/Contents/MacOS
-	cp com.docker.slirp _build/root/Contents/MacOS/com.docker.slirp
+	cp vpnkit _build/root/Contents/MacOS/vpnkit
 	dylibbundler -od -b \
-		-x _build/root/Contents/MacOS/com.docker.slirp \
+		-x _build/root/Contents/MacOS/vpnkit \
 		-d _build/root/Contents/Resources/lib \
 		-p @executable_path/../Resources/lib
-	tar -C _build/root -cvzf com.docker.slirp.tgz Contents
+	tar -C _build/root -cvzf vpnkit.tgz Contents
 
-.PHONY: com.docker.slirp.exe
-com.docker.slirp.exe: src/bin/depends.ml setup.data
+.PHONY: vpnkit.exe
+vpnkit.exe: src/bin/depends.ml setup.data
 	ocaml setup.ml -build
-	cp _build/src/bin/main.native com.docker.slirp.exe
+	cp _build/src/bin/main.native vpnkit.exe
 
-.PHONY: com.docker.slirp
-com.docker.slirp: src/bin/depends.ml setup.data
+.PHONY: vpnkit
+vpnkit: src/bin/depends.ml setup.data
 	ocaml setup.ml -build
-	cp _build/src/bin/main.native com.docker.slirp
+	cp _build/src/bin/main.native vpnkit
 
 setup.data: _oasis
 	oasis setup
@@ -80,7 +80,7 @@ COMMIT:
 .PHONY: clean
 clean:
 	rm -rf _build
-	rm -f com.docker.slirp
-	rm -f com.docker.slirp.tgz
+	rm -f vpnkit
+	rm -f vpnkit.tgz
 	rm -f src/bin/depends.ml
 	rm -f setup.data

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ opam install --deps-only slirp
 make
 ```
 
-When the build succeeds the `com.docker.slirp` binary should be available in the current path.
+When the build succeeds the `vpnkit` binary should be available in the current path.
 
 Running with hyperkit
 ---------------------
 
-First ask `com.docker.slirp` to listen for ethernet connections on a local Unix domain socket:
+First ask `vpnkit` to listen for ethernet connections on a local Unix domain socket:
 ```
-com.docker.slirp --ethernet /tmp/ethernet --debug
+vpnkit --ethernet /tmp/ethernet --debug
 ```
 Next ask [com.docker.hyperkit](https://github.com/docker/hyperkit) to connect a NIC to this
 socket by adding a command-line option like `-s 2:0,virtio-vpnkit,path=/tmp/ethernet`. Note:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,6 @@ build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/scripts/appveyor.sh'"
 
 artifacts:
-  - path: "com.docker.slirp.exe"
+  - path: "vpnkit.exe"
   - path: "OSS-LICENSES"
   - path: "COMMIT"

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ machine:
     OPAM_COMP: "4.03.0"
 general:
   artifacts:
-  - com.docker.slirp.tgz
+  - vpnkit.tgz
   - COMMIT
   - OSS-LICENSES
 dependencies:


### PR DESCRIPTION
Previously the repo was called `vpnkit` but the artifact was called
`com.docker.slirp`. This patch renames the artifact `vpnkit`.

Signed-off-by: David Scott <dave.scott@docker.com>