### PR TITLE
Fix src/dst when parsing Ethernet frames

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,15 @@
+PKG protocol-9p protocol-9p.unix cstruct cstruct.lwt lwt.unix io-page.unix logs
+PKG mirage-types.lwt astring named-pipe.lwt
+PKG cmdliner alcotest lwt.unix logs.fmt dns.mirage lwt.preemptive
+PKG hvsock hvsock.lwt-unix datakit-server.fs9p win-eventlog asl
+PKG ipaddr mirage-flow ppx_sexp_conv pcap-format mirage-console.unix tcpip
+PKG charrua-core dns uwt lwt threads dns-forward tar
+
+B _build/**
+B src/com.docker.slirp/_build/**
+
+S src/hostnet/
+S src/hostnet_test/
+S src/ofs/
+S src/bin/
+S src/com.docker.slirp/src/

--- a/src/hostnet/frame.ml
+++ b/src/hostnet/frame.ml
@@ -29,7 +29,7 @@ let parse bufs =
       match dst_option, src_option with
       | None, _ -> Error (`Msg "failed to parse ethernet destination MAC")
       | _, None -> Error (`Msg "failed to parse ethernet source MAC")
-      | Some src, Some dst ->
+      | Some dst, Some src ->
         let inner = Cstructs.shift bufs 14 in
         ( match ethertype with
           | 0x0800 ->


### PR DESCRIPTION
Fixes a bug where src and dst fields were swapped during Ethernet frame parsing. From a quick grep it looks like these fields are not actually in use at the moment, but at least they should now be correct if they are needed in the future.

Also adds a .merlin file to the project.