### PR TITLE
Fix ethernet parsing bug, add l2 bridge

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,0 +1,15 @@
+PKG protocol-9p protocol-9p.unix cstruct cstruct.lwt lwt.unix io-page.unix logs
+PKG mirage-types.lwt astring named-pipe.lwt
+PKG cmdliner alcotest lwt.unix logs.fmt dns.mirage lwt.preemptive
+PKG hvsock hvsock.lwt-unix datakit-server.fs9p win-eventlog asl
+PKG ipaddr mirage-flow ppx_sexp_conv pcap-format mirage-console.unix tcpip
+PKG charrua-core dns uwt lwt threads dns-forward tar
+
+B _build/**
+B src/com.docker.slirp/_build/**
+
+S src/hostnet/
+S src/hostnet_test/
+S src/ofs/
+S src/bin/
+S src/com.docker.slirp/src/

--- a/.merlin
+++ b/.merlin
@@ -4,6 +4,7 @@ PKG cmdliner alcotest lwt.unix logs.fmt dns.mirage lwt.preemptive
 PKG hvsock hvsock.lwt-unix datakit-server.fs9p win-eventlog asl
 PKG ipaddr mirage-flow ppx_sexp_conv pcap-format mirage-console.unix tcpip
 PKG charrua-core dns uwt lwt threads dns-forward tar
+PKG mirage-vnetif
 
 B _build/**
 B src/com.docker.slirp/_build/**

--- a/_oasis
+++ b/_oasis
@@ -27,7 +27,7 @@ Library hostnet
     ppx_sexp_conv, pcap-format, mirage-console.unix, tcpip.ethif,
     tcpip.arpv4, tcpip.ipv4, tcpip.icmpv4, tcpip.udp, tcpip.tcp, tcpip.stack-direct,
     charrua-core.server, dns, dns.lwt, ofs, uwt, uwt.ext, uwt.preemptive,
-    lwt.preemptive, threads, astring, datakit-server.vfs, dns-forward, tar
+    lwt.preemptive, threads, astring, datakit-server.vfs, dns-forward, tar, mirage-vnetif
 
 Executable test_lwt
   Path: src/hostnet_test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
 install:
   - cmd: git config core.symlinks true
   - cmd: git reset --hard
-  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils.3.5-1 -P make -P unzip -P git -P perl -P mingw64-x86_64-gcc-core"
+  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils.3.5-1 -P make -P git -P perl -P mingw64-x86_64-gcc-core"
 
 build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/scripts/appveyor.sh'"

--- a/opam
+++ b/opam
@@ -55,4 +55,5 @@ depends: [
   "astring"
   "mirage-flow" { >= "1.1.0" }
   "mirage-types-lwt"
+  "mirage-vnetif" 
 ]

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -275,6 +275,7 @@ let main_t socket_url port_control_url introspection_url diagnostics_url max_con
       get_domain_search = (fun () -> []);
       get_domain_name = (fun () -> "local");
       global_arp_table;
+      bridge_connections = false;
       mtu = 1500; } in
 
   let config = match db_path with

--- a/src/hostnet/dhcp.mli
+++ b/src/hostnet/dhcp.mli
@@ -5,7 +5,7 @@ module Make(Netif: V1_LWT.NETWORK): sig
   type t
 
   val make: client_macaddr:Macaddr.t -> server_macaddr:Macaddr.t
-    -> peer_ip: Ipaddr.V4.t -> local_ip:Ipaddr.V4.t
+    -> peer_ip: Ipaddr.V4.t -> highest_peer_ip: Ipaddr.V4.t option -> local_ip:Ipaddr.V4.t
     -> extra_dns_ip:Ipaddr.V4.t list -> get_domain_search:(unit -> string list)
     -> get_domain_name:(unit -> string)
     -> Netif.t -> t

--- a/src/hostnet/frame.ml
+++ b/src/hostnet/frame.ml
@@ -29,7 +29,7 @@ let parse bufs =
       match dst_option, src_option with
       | None, _ -> Error (`Msg "failed to parse ethernet destination MAC")
       | _, None -> Error (`Msg "failed to parse ethernet source MAC")
-      | Some src, Some dst ->
+      | Some dst, Some src ->
         let inner = Cstructs.shift bufs 14 in
         ( match ethertype with
           | 0x0800 ->

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -652,7 +652,15 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
     (* Listen on local IPs *)
     let local_ips = local_ip :: extra_dns_ip in
 
-    let dhcp = Dhcp.make ~client_macaddr ~server_macaddr ~peer_ip ~local_ip
+    let highest_peer_ip = 
+        if use_bridge then begin (* number of IPs supported on virtual network, arbitrarily chosen *)
+            let ip_range = Int32.of_int 250 in
+            Some (Ipaddr.V4.of_int32 (Int32.add (Ipaddr.V4.to_int32 peer_ip) ip_range))
+        end else begin
+            None (* just set smallest available prefix *)
+        end 
+    in
+    let dhcp = Dhcp.make ~client_macaddr ~server_macaddr ~peer_ip ~highest_peer_ip ~local_ip
       ~extra_dns_ip ~get_domain_search ~get_domain_name switch in
 
     let endpoints = IPMap.empty in

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -713,7 +713,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
         Vnet.set_listen_fn t.l2_switch t.l2_client_id (fun buf -> 
             match parse [ buf ] with
             | Ok (Ethernet { src = eth_src ; dst = eth_dst ; _ }) -> 
-                Log.info (fun f -> f "%d: received from bridge %s->%s, sent to switch.write" l2_client_id (Macaddr.to_string eth_src) (Macaddr.to_string eth_dst));
+                Log.debug (fun f -> f "%d: received from bridge %s->%s, sent to switch.write" l2_client_id (Macaddr.to_string eth_src) (Macaddr.to_string eth_dst));
                 Switch.write switch buf 
             | _ -> Lwt.return_unit ); (* write packets from virtual network directly to client *)
     end;
@@ -729,17 +729,17 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
                   Macaddr.compare eth_dst server_macaddr = 0 || 
                   Macaddr.compare eth_dst Macaddr.broadcast = 0)) -> (* not to server, client or broadcast.. *)
            if use_bridge then begin
-               Log.info (fun f -> f "%d: forwarded to bridge for %s->%s" l2_client_id (Macaddr.to_string eth_src) (Macaddr.to_string eth_dst));
+               Log.debug (fun f -> f "%d: forwarded to bridge for %s->%s" l2_client_id (Macaddr.to_string eth_src) (Macaddr.to_string eth_dst));
                Vnet.write t.l2_switch t.l2_client_id buf (* pass to virtual network *)
            end else begin
                Lwt.return_unit (* drop if bridge is not used *)
            end
          | Ok (Ethernet { dst = eth_dst ; src = eth_src ; payload = Ipv4 { payload = Udp { dst = 67; _ }; _ }; _ })
          | Ok (Ethernet { dst = eth_dst ; src = eth_src ; payload = Ipv4 { payload = Udp { dst = 68; _ }; _ }; _ }) ->
-           Log.info (fun f -> f "%d: dhcp %s->%s" l2_client_id (Macaddr.to_string eth_src) (Macaddr.to_string eth_dst));
+           Log.debug (fun f -> f "%d: dhcp %s->%s" l2_client_id (Macaddr.to_string eth_src) (Macaddr.to_string eth_dst));
            Dhcp.callback dhcp buf
          | Ok (Ethernet { dst = eth_dst ; src = eth_src ; payload = Arp { op = `Request }; _ }) ->
-           Log.info (fun f -> f "%d: arp %s->%s" l2_client_id (Macaddr.to_string eth_src) (Macaddr.to_string eth_dst));
+           Log.debug (fun f -> f "%d: arp %s->%s" l2_client_id (Macaddr.to_string eth_src) (Macaddr.to_string eth_dst));
            (* Arp.input expects only the ARP packet, with no ethernet header prefix *)
            begin
                if use_bridge then begin (* reply with global table if bridge is in use *)

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -18,6 +18,7 @@ type config = {
   get_domain_search: unit -> string list;
   get_domain_name: unit -> string;
   global_arp_table: arp_table;
+  bridge_connections: bool;
   mtu: int;
 }
 
@@ -51,4 +52,4 @@ end
 val print_pcap: pcap -> string
 
 val default_server_macaddr: Macaddr.t
-
+val default_client_macaddr: Macaddr.t

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -5,6 +5,11 @@ type pcap = (string * int64 option) option
     file will grow without bound; otherwise the file will be closed when it is
     bigger than the given limit. *)
 
+type arp_table = {
+  mutex: Lwt_mutex.t;
+  mutable table: (Ipaddr.V4.t * Macaddr.t) list;
+}
+
 type config = {
   server_macaddr: Macaddr.t;
   peer_ip: Ipaddr.V4.t;
@@ -12,6 +17,7 @@ type config = {
   extra_dns_ip: Ipaddr.V4.t list;
   get_domain_search: unit -> string list;
   get_domain_name: unit -> string;
+  global_arp_table: arp_table;
   mtu: int;
 }
 

--- a/src/hostnet/slirp.mli
+++ b/src/hostnet/slirp.mli
@@ -45,3 +45,4 @@ end
 val print_pcap: pcap -> string
 
 val default_server_macaddr: Macaddr.t
+


### PR DESCRIPTION
Adds an optional bridge with mirage-vnetif. Also fixes a bug where ethernet frames were read with the `src`/`dst` fields swapped and adds a `.merlin` file to the project (this PR subsumes #187).