### PR TITLE
Set bridge mode on by default

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -275,7 +275,7 @@ let main_t socket_url port_control_url introspection_url diagnostics_url max_con
       get_domain_search = (fun () -> []);
       get_domain_name = (fun () -> "local");
       global_arp_table;
-      bridge_connections = false;
+      bridge_connections = true;
       mtu = 1500; } in
 
   let config = match db_path with

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -978,7 +978,7 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
     let mtu = Active_config.hd mtus in
 
     let bridge_connections_path = driver @ [ "slirp"; "bridge-connections" ] in
-    Config.int config ~default:0 bridge_connections_path
+    Config.int config ~default:1 bridge_connections_path
     >>= fun bridge_conn ->
     Lwt.async (fun () -> restart_on_change "slirp/bridge-connections" string_of_int bridge_conn);
     let bridge_connections = ((Active_config.hd bridge_conn) != 0) in


### PR DESCRIPTION
Packets are only routed to bridge if the ethernet frame dst/src do not match client/server side or broadcast. Each connection to vpnkit gets a new mac-address, so this also partially fixes #190. 

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>