### PR TITLE
Allow the config database branch to be changed

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -285,7 +285,7 @@ let main_t socket_url port_control_url introspection_url diagnostics_url max_con
         Host.Sockets.Stream.Unix.connect db_path
         >>= fun x ->
         Lwt_result.return x in
-      Some (Config.create ~reconnect ())
+      Some (Config.create ~reconnect ~branch:"master" ())
     | None ->
       Log.warn (fun f -> f "no database: using hardcoded network configuration values");
       None in

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -285,7 +285,7 @@ let main_t socket_url port_control_url introspection_url diagnostics_url max_con
         Host.Sockets.Stream.Unix.connect db_path
         >>= fun x ->
         Lwt_result.return x in
-      Some (Config.create ~reconnect ~branch:"master" ())
+      Some (Config.create ~reconnect ~branch:"state" ())
     | None ->
       Log.warn (fun f -> f "no database: using hardcoded network configuration values");
       None in

--- a/src/ofs/active_config.mli
+++ b/src/ofs/active_config.mli
@@ -35,7 +35,10 @@ end
 module Make(Time: V1_LWT.TIME)(FLOW: V1_LWT.FLOW): sig
   include S
 
-  val create: ?username:string -> reconnect:(unit -> (FLOW.flow, [ `Msg of string ]) Result.result Lwt.t) -> unit -> t
-  (** [create ?username reconnect] creates an active configuration system
-      backed by the database connected to by [reconnect ()] *)
+  val create: ?username:string -> branch:string
+    -> reconnect:(unit -> (FLOW.flow, [ `Msg of string ]) Result.result Lwt.t)
+    -> unit -> t
+  (** [create ?username branch reconnect] creates an active configuration system
+      backed by the database connected to by [reconnect ()] where the values
+      are read from the [branch] *)
 end


### PR DESCRIPTION
Currently the configuration parameters are read from the "master"
branch. This patch factors out the branch name so it is only written
in one place and can be more easily changed.

Signed-off-by: David Scott <dave.scott@docker.com>