### PR TITLE
Exempt diagnostics from connection limits

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -116,6 +116,7 @@ let start_introspection introspection_url root =
         let module Server = Fs9p.Make(Host.Sockets.Stream.Unix) in
         unix_listen introspection_url
         >>= fun s ->
+        Host.Sockets.Stream.Unix.disable_connection_tracking s;
         Host.Sockets.Stream.Unix.listen s
           (fun flow ->
             Server.accept ~root ~msg:introspection_url flow
@@ -139,6 +140,7 @@ let start_diagnostics diagnostics_url flow_cb =
         Log.info (fun f -> f "starting diagnostics server on: %s" diagnostics_url);
         unix_listen diagnostics_url
         >>= fun s ->
+        Host.Sockets.Stream.Unix.disable_connection_tracking s;
         Host.Sockets.Stream.Unix.listen s flow_cb;
         Lwt.return_unit
       )

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -42,6 +42,11 @@ module type FLOW_SERVER = sig
   val getsockname: server -> address
   (** Query the address the server is bound to *)
 
+  val disable_connection_tracking: server -> unit
+  (** For a particular server, exempt connections from the tracking mechanism.
+      This is intended for internal purposes only (e.g. extracting diagnostics
+      information) *)
+
   type flow
 
   val listen: server -> (flow -> unit Lwt.t) -> unit


### PR DESCRIPTION
Previously when we hit a connection limit we would not be able to produce any diagnostic output, hampering attempts to understand the failure.

This PR allows `server` instances to be exempted from the tracking and exempts both the `.tar` download and the 9P introspection interface.