### PR TITLE
Improve the connection tracking diagnostics

### DIFF
--- a/src/bin/bind.ml
+++ b/src/bin/bind.ml
@@ -100,7 +100,7 @@ module Make(Socket: Sig.SOCKETS) = struct
     module Udp = struct
       include Socket.Datagram.Udp
 
-      let bind (local_ip, local_port) =
+      let bind ?description (local_ip, local_port) =
         match local_ip with
         | Ipaddr.V4 ipv4 ->
           if local_port < 1024 && not is_windows then begin
@@ -109,8 +109,8 @@ module Make(Socket: Sig.SOCKETS) = struct
             | Result.Error (`Msg x) -> Lwt.fail (Failure x)
             | Result.Ok fd ->
               Lwt.return (Socket.Datagram.Udp.of_bound_fd fd)
-          end else bind (local_ip, local_port)
-        | _ -> bind (local_ip, local_port)
+          end else bind ?description (local_ip, local_port)
+        | _ -> bind ?description (local_ip, local_port)
     end
   end
 
@@ -118,7 +118,7 @@ module Make(Socket: Sig.SOCKETS) = struct
     module Tcp = struct
       include Socket.Stream.Tcp
 
-      let bind (local_ip, local_port) =
+      let bind ?description (local_ip, local_port) =
         match local_ip with
         | Ipaddr.V4 ipv4 ->
           if local_port < 1024 && not is_windows then begin
@@ -127,8 +127,8 @@ module Make(Socket: Sig.SOCKETS) = struct
             | Result.Error (`Msg x) -> Lwt.fail (Failure x)
             | Result.Ok fd ->
               Lwt.return (Socket.Stream.Tcp.of_bound_fd fd)
-          end else bind (local_ip, local_port)
-        | _ -> bind (local_ip, local_port)
+          end else bind ?description (local_ip, local_port)
+        | _ -> bind ?description (local_ip, local_port)
     end
 
     module Unix = Socket.Stream.Unix

--- a/src/hostnet/forward.ml
+++ b/src/hostnet/forward.ml
@@ -315,11 +315,12 @@ let start_udp_proxy description vsock_path_var remote_port server =
 let start vsock_path_var t =
   match t.local with
   | `Tcp (local_ip, local_port)  ->
+    let description = Printf.sprintf "forwarding from tcp:%s:%d" (Ipaddr.to_string local_ip) local_port in
     Lwt.catch
       (fun () ->
         check_bind_allowed local_ip
         >>= fun () ->
-        Socket.Stream.Tcp.bind (local_ip, local_port)
+        Socket.Stream.Tcp.bind ~description (local_ip, local_port)
         >>= fun server ->
         t.server <- Some (`Tcp server);
         (* Resolve the local port yet (the fds are already bound) *)
@@ -343,11 +344,12 @@ let start vsock_path_var t =
           Lwt.return (Result.Error (`Msg (Printf.sprintf "Bind for %s:%d: unexpected error %s" (Ipaddr.to_string local_ip) local_port (Printexc.to_string e))))
       )
     | `Udp (local_ip, local_port) ->
+      let description = Printf.sprintf "forwarding from udp:%s:%d" (Ipaddr.to_string local_ip) local_port in
       Lwt.catch
         (fun () ->
           check_bind_allowed local_ip
           >>= fun () ->
-          Socket.Datagram.Udp.bind (local_ip, local_port)
+          Socket.Datagram.Udp.bind ~description (local_ip, local_port)
           >>= fun server ->
           t.server <- Some (`Udp server);
           start_udp_proxy (to_string t) vsock_path_var t.remote_port server

--- a/src/hostnet/hostnet_udp.ml
+++ b/src/hostnet/hostnet_udp.ml
@@ -90,7 +90,7 @@ module Make(Sockets: Sig.SOCKETS)(Time: V1_LWT.TIME) = struct
 
          Lwt.catch
            (fun () ->
-              Udp.bind (Ipaddr.(V4 V4.any), 0)
+              Udp.bind ~description (Ipaddr.(V4 V4.any), 0)
               >>= fun server ->
               let last_use = Unix.gettimeofday () in
               let flow = { description; server; last_use } in

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -36,7 +36,7 @@ module type FLOW_SERVER = sig
   (** Create a server from a file descriptor bound to a Unix domain socket
       by some other process and passed to us. *)
 
-  val bind: address -> server Lwt.t
+  val bind: ?description:string -> address -> server Lwt.t
   (** Bind a server to an address *)
 
   val getsockname: server -> address


### PR DESCRIPTION
Through the diagnostic interface we now see:
    
    drwxrwxr-x ? root root 0 Jan 1 1970 udp:0.0.0.0:0 udp:192.168.65.2:51726-127.0.0.1:123
    
instead of
    
    drwxrwxr-x ? root root 0 Jan 1 1970 udp:0.0.0.0:0

i.e. we see why a listening socket has been created. This will help understand connection leaks.
