### PR TITLE
Improve switching between DNS modes

### DIFF
--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -234,7 +234,7 @@ let main_t socket_url port_control_url introspection_url diagnostics_url max_con
           zones = Domain.Set.empty; timeout_ms = Some 2000; order = 0;
         }
       ] in
-      Dns_policy.add ~priority:1 ~config:{ servers; search = []; assume_offline_after_drops = None } );
+      Dns_policy.add ~priority:1 ~config:(`Upstream { servers; search = []; assume_offline_after_drops = None }) );
 
   let etc_hosts_watch = match Hosts.watch ~path:hosts () with
     | Result.Ok watch -> Some watch

--- a/src/hostnet/hostnet_dns.ml
+++ b/src/hostnet/hostnet_dns.ml
@@ -288,8 +288,6 @@ module Make(Ip: V1_LWT.IPV4) (Udp:V1_LWT.UDPV4) (Tcp:V1_LWT.TCPV4) (Socket: Sig.
       Log.warn (fun f -> f "%s lookup failed: %s" (describe buf) m);
       Lwt.return_unit
     | Result.Ok buffer ->
-      (* Synthesize a packet from the remote to the host i.e. dst *)
-      record_udp ~source_ip:dst ~source_port:53 ~dest_ip:src ~dest_port:src_port [ buffer ];
       Udp.write ~source_port:53 ~dest_ip:src ~dest_port:src_port udp buffer
 
   let handle_tcp ~t =

--- a/src/hostnet/hostnet_dns.mli
+++ b/src/hostnet/hostnet_dns.mli
@@ -2,6 +2,14 @@
 module Policy(Files: Sig.FILES): Sig.DNS_POLICY
 (** Global DNS configuration *)
 
+module Config: sig
+  type t = [
+    | `Upstream of Dns_forward.Config.t (** use upstream servers *)
+    | `Host (** use the host's resolver *)
+  ]
+  val to_string: t -> string
+end
+
 module Make
     (Ip: V1_LWT.IPV4 with type prefix = Ipaddr.V4.t)
     (Udp: V1_LWT.UDPV4)
@@ -15,8 +23,10 @@ module Make
   type t
   (** A DNS proxy instance with a fixed configuration *)
 
-  val create: local_address:Dns_forward.Config.Address.t -> Dns_forward.Config.t -> t Lwt.t
-  (** Create a DNS forwarding instance based on the given configuration.
+  val create: local_address:Dns_forward.Config.Address.t -> Config.t -> t Lwt.t
+  (** Create a DNS forwarding instance based on the given configuration, either
+      [`Upstream config]: send DNS requests to the given upstream servers
+      [`Host]: use the Host's resolver.
       The parameter [~local_address] will be used in any .pcap trace as the
       source address of DNS requests sent from this host. *)
 

--- a/src/hostnet/sig.ml
+++ b/src/hostnet/sig.ml
@@ -224,13 +224,13 @@ module type DNS_POLICY = sig
 
   type priority = int (** higher is more important *)
 
-  val add: priority:priority -> config:Dns_forward.Config.t -> unit
+  val add: priority:priority -> config:[ `Upstream of Dns_forward.Config.t | `Host ] -> unit
   (** Add some configuration at the given priority level *)
 
   val remove: priority:priority -> unit
   (** Remove the configuration at the given priority level *)
 
-  val config: unit -> Dns_forward.Config.t
+  val config: unit -> [ `Upstream of Dns_forward.Config.t | `Host ]
   (** Return the currently active DNS configuration *)
 end
 

--- a/src/hostnet/slirp.ml
+++ b/src/hostnet/slirp.ml
@@ -955,10 +955,10 @@ module Make(Config: Active_config.S)(Vmnet: Sig.VMNET)(Dns_policy: Sig.DNS_POLIC
           >>= fun () ->
           dns := Dns_forwarder.create ~local_address (Dns_policy.config ());
           Lwt.return_unit
-        | Some (config: Dns_forward.Config.t) ->
+        | Some (servers: Dns_forward.Config.t) ->
           let open Dns_forward in
-          Log.info (fun f -> f "updating resolvers to %s" (Config.to_string config));
-          Dns_policy.add ~priority:3 ~config;
+          Log.info (fun f -> f "updating resolvers to %s" (Config.to_string servers));
+          Dns_policy.add ~priority:3 ~config:(`Upstream servers);
           !dns >>= fun t ->
           Dns_forwarder.destroy t
           >>= fun () ->

--- a/src/hostnet_test/slirp_stack.ml
+++ b/src/hostnet_test/slirp_stack.ml
@@ -24,7 +24,7 @@ module Dns_policy = struct
       Ipaddr.of_string_exn "8.8.8.8", 53;
       Ipaddr.of_string_exn "8.8.4.4", 53;
     ] in
-    config_of_ips ips
+    `Upstream (config_of_ips ips)
 
   let add ~priority:_ ~config:_ = ()
   let remove ~priority:_ = ()


### PR DESCRIPTION
Previously we conflated the list of upstream servers to use, with whether to use them or the host resolver. This PR separates these into 2 separate configuration variables

- `slirp/resolver`: `host` means use the host resolver, any other string means use the upstream resolvers
- `slirp/dns`: the current upstream DNS servers

This simplifies the integration into D4D since we can have a background configuration watcher own the `slirp/dns` key and invite the user to change the mode via the `slirp/resolver` key.

This PR also tidies up the diagnostic pcap a little, but removing duplicated packets. 